### PR TITLE
Fix compatibility bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ in development
 * Rename YAQL variables along with the tasks they refer to (new-feature)
 * Add syntax validation (new-feature)
 * Add autocomplete for input parameters (new-feature)
+* Fix compatibility with latest stable Firefox and Safari (bug-fix)
 
 0.2.1 - August 24th, 2015 (alpha-2)
 -----------------------------------

--- a/css/main.css
+++ b/css/main.css
@@ -371,6 +371,8 @@ main {
     padding: 5px;
     z-index: 1;
 
+    -webkit-user-drag: element;
+
     display: flex;
 
     & > * {
@@ -394,7 +396,7 @@ main {
         border-radius: 3px;
       }
 
-      img:not([src]) {
+      img[src=''] {
         display: none;
       }
     }

--- a/js/lib/definition.js
+++ b/js/lib/definition.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import Sector from './models/sector';
 
 export default class Definition {
@@ -26,7 +28,7 @@ export default class Definition {
 
         if (task.isEmpty()) {
           if (task.starter === _prefix) {
-            task.indent = state.unit.repeat(_prefix.length);
+            task.indent = _.repeat(state.unit, _prefix.length);
           } else {
             task.starter += _prefix;
           }

--- a/js/lib/definitions/mistral.js
+++ b/js/lib/definitions/mistral.js
@@ -16,11 +16,11 @@ export default class MistralDefinition extends Definition {
     return {
       indents: {
         base: '',
-        workflow: unit.repeat(1),
-        tasks: unit.repeat(2),
-        task: unit.repeat(3),
-        property: unit.repeat(4),
-        transition: unit.repeat(5)
+        workflow: _.repeat(unit, 1),
+        tasks: _.repeat(unit, 2),
+        task: _.repeat(unit, 3),
+        property: _.repeat(unit, 4),
+        transition: _.repeat(unit, 5)
       }
     };
   }
@@ -168,7 +168,7 @@ export default class MistralDefinition extends Definition {
         const sector = state.currentWorkflow.getSector('taskBlock');
         sector.setStart(lineNum, 0);
         sector.setEnd(lineNum + 1, 0);
-        sector.indent = state.unit.repeat(state.isTaskBlock - 1);
+        sector.indent = _.repeat(state.unit, state.isTaskBlock - 1);
         return;
       }
 
@@ -233,7 +233,7 @@ export default class MistralDefinition extends Definition {
         if (block.enter(line, lineNum, state)) {
           const sector = state.currentTask.getSector('success');
           sector.setStart(lineNum, 0);
-          sector.indent = state.unit.repeat(state.isSuccessBlock - 1);
+          sector.indent = _.repeat(state.unit, state.isSuccessBlock - 1);
           return;
         }
 
@@ -273,7 +273,7 @@ export default class MistralDefinition extends Definition {
         if (block.enter(line, lineNum, state)) {
           const sector = state.currentTask.getSector('error');
           sector.setStart(lineNum, 0);
-          sector.indent = state.unit.repeat(state.isErrorBlock - 1);
+          sector.indent = _.repeat(state.unit, state.isErrorBlock - 1);
           return;
         }
 
@@ -313,7 +313,7 @@ export default class MistralDefinition extends Definition {
         if (block.enter(line, lineNum, state)) {
           const sector = state.currentTask.getSector('complete');
           sector.setStart(lineNum, 0);
-          sector.indent = state.unit.repeat(state.isCompleteBlock - 1);
+          sector.indent = _.repeat(state.unit, state.isCompleteBlock - 1);
           return;
         }
 
@@ -426,7 +426,7 @@ export default class MistralDefinition extends Definition {
           _.each(TYPES, (type) => {
             const sector = new Sector().setType(type)
                 , outdent = state.taskBlock.indent
-                , unit = state.unit.repeat(starter.length - outdent.length)
+                , unit = _.repeat(state.unit, starter.length - outdent.length)
                 ;
 
             sector.indent = starter + unit;

--- a/js/lib/models/node.js
+++ b/js/lib/models/node.js
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import 'object.observe';
 
 import intersectRect from '../util/intersect-rect';
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "lodash": "^3.9.3",
     "mixin": "^0.2.0",
     "normalize.css": "^3.0.3",
+    "object.observe": "^0.2.4",
     "react": "^0.13.3",
     "revalidator": "^0.3.1",
     "st2client": "^0.3.7"


### PR DESCRIPTION
- String.repeat support is spotty to date
- Object.observe is missing in some browsers
- Transform style requires prefix in Safari
- Chrome and Safari handle effectAllowed differently
- Safari has problems determining element visibility for setDragImage (solved by cloning the element and hiding it behind palette, at the same time solving another bug in Chrome)
- FF and Safari tries to load `undefined` icons
