### PR TITLE
Embed coordinates on transition

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -471,6 +471,8 @@ class Main extends React.Component {
       throw new Error('no such task:', source);
     }
 
+    this.embedCoords();
+
     const params = _.map(transitions, (name) => ({ name }));
 
     let block = this.model.fragments.transitions(task, params, type);


### PR DESCRIPTION
Initially, I was planning to only embed coordinates on changes that affect the position of at least a single node, though, it seems like due to some complex feedback loop, the target node gets repositioned on transition changes no matter what.

Now when I'm thinking about it, changes in transitions or number of nodes would also affect how graph would look like next time, so it makes sense to embed coordinates in this cases too.
