### PR TITLE
Put cursor on a selected task

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -145,7 +145,7 @@ class Main extends React.Component {
         , sector = _.first(sectors)
         ;
 
-      if (sector && sector.task) {
+      if (!this._bulk && sector && sector.task) {
         this.graph.select(sector.task.getProperty('name'));
       }
     });
@@ -209,7 +209,8 @@ class Main extends React.Component {
           this.rename(name);
           break;
         default:
-          this.graph.select(name);
+          const { row, column } = this.model.task(name).getSector('name').start;
+          this.editor.selection.moveTo(row, column);
       }
     });
 


### PR DESCRIPTION
This patch tries to solve the problem of making multiple transitions from the same node.

Before the change, if you select the node and then connect it to another one, selection wil jump to the node editor cursor positioned on (often, the last one). So, to make multiple connections from the same node, you would have to select it after each connection. Annoying and not intuitive.

After this change, selecting a node on the canvas would automatically place the cursor at the beginning of its name making sure that both the selected node and the node having a cursor is always the same node.

Downside is that cursor movement may not also be intuitive for the user. Besides, user may expect cursor to appear on the beginning of the first line of the task rather than on the beginning of the name. The problem here is that first character of the first line belongs to the previous task (it is hard to explain, just see for yourself) and it goes deep inside how parser works and what kind of assumtions we had to make for this thing to work in the first place.
