### PR TITLE
Suggest autocomplete for empty prefix

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -103,6 +103,7 @@ class Main extends React.Component {
     });
 
     editor.setOptions({
+      enableBasicAutocompletion: true,
       enableLiveAutocompletion: true
     });
 


### PR DESCRIPTION
Live autocomplete only works when you know at least a single letter.

If you're absolutely clueless of the action parameters, press `ctrl`+`space` (or alternatively, `ctr`+`shift`+`space` or `alt`+`space`) to show the list of all suggestions.
