### PR TITLE
Postrm should finish successfully if there is no webui config

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -5,7 +5,7 @@ WEBUI_CONFIGJS="/opt/stackstorm/static/webui/config.js"
 injecthdr="// Package injected:"
 
 jsremove_flow() {
-  [ -f "$WEBUI_CONFIGJS" ] || { echo "St2web \`${WEBUI_CONFIGJS}' not found"; exit 1; }
+  [ -f "$WEBUI_CONFIGJS" ] || { echo "St2web \`${WEBUI_CONFIGJS}' not found"; exit 0; }
   perl -pi -0e "s#${injecthdr} flow-config(.|\n)*${injecthdr} flow-config\n##" $WEBUI_CONFIGJS
 }
 

--- a/rpm/postrm_script.spec
+++ b/rpm/postrm_script.spec
@@ -4,6 +4,6 @@ WEBUI_CONFIGJS=%{webui_configjs}
 injecthdr="// Package injected:"
 
 jsremove_flow() {
-  [ -f "$WEBUI_CONFIGJS" ] || { echo "St2web \`${WEBUI_CONFIGJS}' not found"; exit 1; }
+  [ -f "$WEBUI_CONFIGJS" ] || { echo "St2web \`${WEBUI_CONFIGJS}' not found"; exit 0; }
   perl -pi -0e "s#${injecthdr} flow-config(.|\n)*${injecthdr} flow-config\n##" $WEBUI_CONFIGJS
 }


### PR DESCRIPTION
The config might have been removed before or moved to another location by user. In any case, it's outside of our control.
