### PR TITLE
Add boilerplate code if virtual editor is blank

### DIFF
--- a/lib/model/index.js
+++ b/lib/model/index.js
@@ -47,7 +47,7 @@ export default class Model extends EventEmitter {
   }
 
   fragments = {
-    task: (params) => {
+    workflow: () => {
       let result = '';
 
       const defs = this.definition.defaults.indents;
@@ -65,6 +65,7 @@ export default class Model extends EventEmitter {
         };
 
         result += this.definition.template.block.wf_workflow(defs.workflow, defs.tasks)(workflow);
+        result += this.definition.template.block.tasks(defs.tasks)();
 
         const params = this.action.parameters;
         if (params) {
@@ -75,13 +76,37 @@ export default class Model extends EventEmitter {
             })
             .value();
 
-          result += this.fragments.input(defs.tasks, defs.task + '- ', fields);
+            result += this.fragments.input(defs.tasks, defs.task + '- ', fields);
+        }
+      } else if (this.virtualEditor.getLength() === 1) {
+        result += this.definition.template.block.wf_base()({
+          name: this.action && this.action.ref || 'untitled'
+        });
+
+        const workflow = this.workflows[0]
+
+        result += this.definition.template.block.wf_workflow(defs.workflow, defs.tasks)(workflow);
+        result += this.definition.template.block.tasks(defs.tasks)();
+
+        const params = this.action.parameters;
+        if (params) {
+          const fields = _(params).chain()
+            .keys()
+            .reject((e) => {
+              return _.includes(this.definition.runner_params, e);
+            })
+            .value();
+
+            result += this.fragments.input(defs.tasks, defs.task + '- ', fields);
         }
       }
 
-      if (!this.taskBlock || this.taskBlock.isUndefined()) {
-        result += this.definition.template.block.tasks(defs.tasks)();
-      }
+      return result;
+    },
+    task: (params) => {
+      let result = '';
+
+      const defs = this.definition.defaults.indents;
 
       const specimen = _(this.tasks)
         .groupBy(task => task.starter)
@@ -354,6 +379,8 @@ export default class Model extends EventEmitter {
         , name = `task${index}`
         ;
 
+    let workflow = this.fragments.workflow();
+
     let task = this.fragments.task({
       name: name,
       ref: actionRef,
@@ -361,8 +388,10 @@ export default class Model extends EventEmitter {
       y: y
     });
 
+    task = workflow + task
+
     const cursor = ((block) => {
-      if (block && !block.isEnd()) {
+      if (block && !block.isEnd() && this.virtualEditor.getLength() > 1) {
         const range = new Range();
         range.setStart(block.end);
         range.setEnd(block.end);

--- a/tests/test_mistral_definition.js
+++ b/tests/test_mistral_definition.js
@@ -21,12 +21,14 @@ describe('Mistral definition', () => {
   describe('cases', () => {
 
     it('should properly output task fragment even before the parse', () => {
-      const taskStrings = model.fragments.task({
-        name: 'some',
-        ref: 'thing',
-        x: 0,
-        y: 0
-      });
+      const taskStrings =
+        model.fragments.workflow() +
+        model.fragments.task({
+          name: 'some',
+          ref: 'thing',
+          x: 0,
+          y: 0
+        });
 
       expect(taskStrings).to.deep.equal([
         `---`,
@@ -54,12 +56,14 @@ describe('Mistral definition', () => {
 
       // Fragments
 
-      const taskStrings = model.fragments.task({
-        name: 'some',
-        ref: 'thing',
-        x: 0,
-        y: 0
-      });
+      const taskStrings =
+        model.fragments.workflow() +
+        model.fragments.task({
+          name: 'some',
+          ref: 'thing',
+          x: 0,
+          y: 0
+        });
 
       expect(taskStrings).to.deep.equal([
         `---`,
@@ -113,7 +117,6 @@ describe('Mistral definition', () => {
       // indent from adjacent blocks
       // TODO: Fix indentation calculation for workbook with empty task block
       expect(taskStrings).to.deep.equal([
-        '  tasks:',
         '    some:',
         '      # [0, 0]',
         '      action: thing',
@@ -156,7 +159,6 @@ describe('Mistral definition', () => {
       });
 
       expect(taskStrings).to.deep.equal([
-        '  tasks:',
         '    some:',
         '      # [0, 0]',
         '      action: thing',


### PR DESCRIPTION
If user deletes the code in the virtual editor and then tries to add a new task, the boiler plate code is lost. This patch checks to see if the virtual editor is empty and if so, adds the boiler plate code again when new task is added.