### PR TITLE
Show action name instead of ref in the pallette

### DIFF
--- a/lib/panels/palette.js
+++ b/lib/panels/palette.js
@@ -77,8 +77,9 @@ class Action extends React.Component {
   }
 
   render() {
+    const [, name] = this.props.action.ref.split('.');
     return <div className={st2Class('action')} draggable={true} onDragStart={this.drag.bind(this)}>
-      <div className={st2Class('action-name')}>{this.props.action.ref}</div>
+      <div className={st2Class('action-name')}>{name}</div>
       <div className={st2Class('action-description')}>{this.props.action.description}</div>
     </div>;
   }


### PR DESCRIPTION
Fixes stackstorm/st2#2065.

By analogy with https://github.com/StackStorm/st2web/pull/334

<img width="233" alt="screen shot 2016-11-21 at 3 45 14 pm" src="https://cloud.githubusercontent.com/assets/1357357/20476040/8bc8e3b0-b001-11e6-9fc1-807cdd0aaafd.png">
