### PR TITLE
Add tooltips to the buttons in the center bar

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -189,7 +189,7 @@ class Main extends React.Component {
             </ControlGroup>
             <ControlGroup position='center'>
               <Control icon="redirect" onClick={this.undo.bind(this)} title="Undo last operation"/>
-              <Control icon="redirect2" onClick={this.redo.bind(this)} title="Redo laste operation"/>
+              <Control icon="redirect2" onClick={this.redo.bind(this)} title="Redo last operation"/>
               <Control icon="arrange" onClick={this.layout.bind(this)} title="Automatically rearrange nodes in the workflow"/>
               <CatchControl icon="save" onClick={this.save.bind(this)} title="Save this workflow" />
               <ExecutionControl ref="executionControl"


### PR DESCRIPTION
Small UX improvement.

We do have a tutorial which describes what each button does, but some people skip the tutorial or similar so it's friendlier if we show a tool-tip / help text which explains what each icon does.