### PR TITLE
Fix: Once enum created you can't remove

### DIFF
--- a/lib/util/forms.js
+++ b/lib/util/forms.js
@@ -148,10 +148,11 @@ export const specTypes = {
       props: {
         value: (this.props.value || []).join(', '),
         onChange: (event) => {
-          const value = event.target.value
-            .split(',')
-            .map(_.trim)
-            ;
+          const value = (
+            (event.target.value !== "" && event.target.value !== undefined) ?
+              event.target.value.split(',').map(_.trim) :
+              undefined
+          );
 
           return this.handleChange(value);
         }


### PR DESCRIPTION
Fixes #113 

When the value of `enum` moves from `undefined` to an empty string `.split()` is working its javascript magic over it to interpret `""` as `[""]` which causes the `enum` block to always stay in the param definition with a single option of an empty string. This PR checks the pre split value and sets it to unassigned again if the string is empty.