### PR TITLE
Remove Debian Wheezy and Jessie

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
   node:
     version: 4
   environment:
-    DEB: wheezy jessie trusty xenial
+    DEB: trusty xenial
     RPM: el6 el7
     IS_ENTERPRISE: 1
     DEPLOY_PACKAGES: 1


### PR DESCRIPTION
Partial work on https://github.com/StackStorm/st2-packages/issues/365 to remove Debian `wheezy` and `jessie` packages.