### PR TITLE
Pin ruby version to 2.0.0 for package_cloud

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 # Setup in CircleCI account the following ENV variables:
 # PACKAGECLOUD_TOKEN
 machine:
+  ruby:
+    version: ruby-2.0.0-p645
   node:
     version: 4
   environment:


### PR DESCRIPTION
After this fix last time: [Pin 'package_cloud' gem version to '0.2.45'](https://github.com/StackStorm/st2flow/pull/126)

builds are now failing because `rake requires Ruby version >= 2.0.0.`

```
gem install package_cloud -v 0.2.45
Fetching: thor-0.20.0.gem (100%)
Successfully installed thor-0.20.0
Fetching: highline-1.6.20.gem (100%)
Successfully installed highline-1.6.20
Fetching: mime-types-2.99.3.gem (100%)
Successfully installed mime-types-2.99.3
Fetching: netrc-0.11.0.gem (100%)
Successfully installed netrc-0.11.0
Fetching: rest-client-1.7.3.gem (100%)
Successfully installed rest-client-1.7.3
Fetching: json_pure-1.8.1.gem (100%)
Successfully installed json_pure-1.8.1
Fetching: rake-12.3.0.gem (100%)
ERROR:  Error installing package_cloud:
	rake requires Ruby version >= 2.0.0.

gem install package_cloud -v 0.2.45 returned exit code 1

Action failed: gem install package_cloud -v 0.2.45
```
On the container:

```
ubuntu@box1413:~$ gem install package_cloud -v 0.2.45
ERROR:  Error installing package_cloud:
    rake requires Ruby version >= 2.0.0.
```
```
ubuntu@box1413:~$ sudo gem install package_cloud -v 0.2.45
Fetching: thor-0.20.0.gem (100%)
Fetching: highline-1.6.20.gem (100%)
Fetching: mime-types-2.99.3.gem (100%)
ERROR:  Error installing package_cloud:
    mime-types requires Ruby version >= 1.9.2.
ubuntu@box1413:~$
```
and current ruby version is:

```
ubuntu@box1413:~$ ruby --version
ruby 1.9.3p448 (2013-06-27 revision 41675) [x86_64-linux]
```
Pinned ruby version to 2.0.0 as per: https://circleci.com/docs/1.0/configuration/#ruby-version