### PR TITLE
Make sure we include static/ directory in the final gulp and package build

### DIFF
--- a/modules/tasks/settings.json
+++ b/modules/tasks/settings.json
@@ -16,6 +16,7 @@
     "static": [
       "index.html",
       "img/*",
+      "static/*",
       "font/*",
       "favicon.ico"
     ],


### PR DESCRIPTION
This pull request updates gulp config to make sure we include ``static/`` directory in the final package build.

This should fix #193.

Resolves #193.