### PR TITLE
Allow for deletion of last task

### DIFF
--- a/modules/st2flow-model/schemas/orquesta.json
+++ b/modules/st2flow-model/schemas/orquesta.json
@@ -168,7 +168,7 @@
           }
         }
       },
-      "minProperties": 1
+      "minProperties": 0
     },
     "description": {
       "minLength": 1,


### PR DESCRIPTION
As described in issue #210, an error message that appears when
deleting the remaining task from the workflow. This PR reduces the
required number of task properties to 0 from 1.