### PR TITLE
Don't make bundled transitions in Orquesta transition details based on condition

### DIFF
--- a/modules/st2flow-canvas/index.js
+++ b/modules/st2flow-canvas/index.js
@@ -14,6 +14,7 @@ import { connect } from 'react-redux';
 import { PropTypes } from 'prop-types';
 import cx from 'classnames';
 import fp from 'lodash/fp';
+import { uniqueId } from 'lodash';
 
 import Notifications from '@stackstorm/st2flow-notifications';
 
@@ -53,7 +54,7 @@ type Wheel = WheelEvent & {
 export default class Canvas extends Component<{
       children: Node,
       className?: string,
-      
+
       navigation: Object,
       navigate: Function,
 
@@ -345,6 +346,7 @@ export default class Canvas extends Component<{
         });
 
         return {
+          id: uniqueId(`${transition.from.name}-`),
           transition,
           group,
           color: transition.color,
@@ -356,7 +358,7 @@ export default class Canvas extends Component<{
         const { task, toTasks = [] } = navigation;
         return transition.from.name === task && fp.isEqual(toTasks, transition.to.map(t => t.name));
       });
-    
+
     return (
       <div
         className={cx(this.props.className, this.style.component)}
@@ -420,7 +422,7 @@ export default class Canvas extends Component<{
                 transitionGroups
                   .map(({ id, transition, group, color }, i) => (
                     <TransitionGroup
-                      key={`${transition.from.name}-${window.btoa(transition.condition)}`}
+                      key={`${id}-${window.btoa(transition.condition)}`}
                       color={color}
                       transitions={group}
                       selected={false}
@@ -432,7 +434,7 @@ export default class Canvas extends Component<{
                 selectedTransitionGroups
                   .map(({ id, transition, group, color }, i) => (
                     <TransitionGroup
-                      key={`${transition.from.name}-${window.btoa(transition.condition)}-selected`}
+                      key={`${id}-${window.btoa(transition.condition)}-selected`}
                       color={color}
                       transitions={group}
                       selected={true}

--- a/modules/st2flow-details/task-details.js
+++ b/modules/st2flow-details/task-details.js
@@ -163,16 +163,7 @@ export default class TaskDetails extends Component<TaskDetailsProps, {
       return false;
     }
 
-    const trans = !!selected && transitions
-      .filter(transition => transition.from.name === task.name)
-      .reduce((acc, transition) => {
-        const t = acc.find(t => t.condition === transition.condition);
-        if (!t) {
-          return acc.concat({ ...transition });
-        }
-        t.to = t.to.concat(transition.to);
-        return acc;
-      }, []);
+    const trans = !!selected && transitions;
 
     const action = actions.find(({ref}) => ref === task.action);
 


### PR DESCRIPTION
For #216.  Using the base model transition instead of a repackaged one lets updates from the transition details panel happen seamlessly.

<img width="1257" alt="screen shot 2019-02-06 at 2 08 25 pm" src="https://user-images.githubusercontent.com/18686722/52366885-c9848e00-2a18-11e9-9832-57a8a2f30504.png">
