### PR TITLE
Use locale-based case insensitive search for palette

### DIFF
--- a/modules/st2flow-palette/index.js
+++ b/modules/st2flow-palette/index.js
@@ -54,7 +54,7 @@ export default class Palette extends Component<{
         <div className={this.style.list}>
           {
             actions
-              .filter(action => action.ref.indexOf(search) > -1)
+              .filter(action => action.ref.toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) > -1)
               .reduce((acc, action) => {
                 let pack = acc.find(pack => pack.name === action.pack);
                 if (!pack) {


### PR DESCRIPTION
For #209

<img width="354" alt="screen shot 2019-02-06 at 3 26 38 pm" src="https://user-images.githubusercontent.com/18686722/52371476-a1e6f300-2a23-11e9-984a-d25f50c7a8c2.png">
