### PR TITLE
Allow undo to blank canvas

### DIFF
--- a/store.js
+++ b/store.js
@@ -43,7 +43,7 @@ function getRanges(model) {
 
 const flowReducer = (state = {}, input) => {
   const {
-    workflowSource = 'version: 1.0\ntasks: {}',
+    workflowSource = workflowModel.constructor.minimum,
     metaSource = '',
     pack = 'default',
     meta = {


### PR DESCRIPTION
Current implementation errors out when you undo to blank canvas. This PR adds a default workflow definition to the reducer store so that a valid workflow is present when you begin the workflow.

Fixes #203 