### PR TITLE
Rename transitions on task rename

### DIFF
--- a/modules/st2flow-model/model-orquesta.js
+++ b/modules/st2flow-model/model-orquesta.js
@@ -205,23 +205,34 @@ class OrquestaModel extends BaseModel implements ModelInterface {
     Object.keys(tasks).map((taskKey) => {
       const nextElements = _.get(tasks[taskKey], 'next', []);
       nextElements.map((nextElement, elementIndex) => {
-        let nextTasks = _.get(nextElement, 'do', []);
+        const nextTasks = _.get(nextElement, 'do', []);
         if (typeof nextTasks === 'string') {
-          nextTasks = [ nextTasks ];
-        }
-        nextTasks.map((nextTask, taskIndex) => {
-          if (nextTask === ref.name) {
+          if (nextTasks === ref.name) {
             const transitionPath = [
               'tasks',
               taskKey,
               'next',
               elementIndex,
               'do',
-              taskIndex,
             ];
             crawler.renameMappingKey(this.tokenSet, transitionPath, name);
           }
-        });
+        }
+        else {
+          nextTasks.map((nextTask, taskIndex) => {
+            if (nextTask === ref.name) {
+              const transitionPath = [
+                'tasks',
+                taskKey,
+                'next',
+                elementIndex,
+                'do',
+                taskIndex,
+              ];
+              crawler.renameMappingKey(this.tokenSet, transitionPath, name);
+            }
+          });
+        }
       });
     });
   }


### PR DESCRIPTION
Current task rename does not also rename task transitions. This can cause the
application to crash since the transitions need to reflect the actual name of
the task. This PR adds a method to the orquesta model to update task
transitions when the task name is changed.

Fixes #219 