### PR TITLE
This PR fixes #225. I am disabling the Rename button if the changed task

### DIFF
--- a/modules/st2flow-details/task-details.js
+++ b/modules/st2flow-details/task-details.js
@@ -189,7 +189,7 @@ export default class TaskDetails extends Component<TaskDetailsProps, {
           rename
             && (
               <div className={cx(this.style.button, this.style.rename)} >
-                <Button onClick={() => this.handleTaskRename(task.name, name)} value="Rename" disabled={_.includes(tasks.map(task=>task.name),name) ? 'disabled' : ''} />
+                <Button onClick={() => this.handleTaskRename(task.name, name)} value="Rename" disabled={_.includes(tasks.map(task => task.name),name) ? 'disabled' : ''} />
               </div>
             )
         }


### PR DESCRIPTION
name matches any of the existing tasks name. Thus resticting the user to
provide same name as any existing tasks name.