### PR TITLE
Add a key chord for undo/redo of actions in flow

### DIFF
--- a/modules/st2flow-canvas/index.js
+++ b/modules/st2flow-canvas/index.js
@@ -400,10 +400,6 @@ export default class Canvas extends Component<{
   canvasRef = React.createRef();
   surfaceRef = React.createRef();
 
-  keyMap = {
-    'handleTaskDelete': [ 'del', 'backspace' ],
-  };
-
   render() {
     const { children, navigation, tasks=[], transitions=[], isCollapsed, toggleCollapse } = this.props;
     const { scale } = this.state;
@@ -452,8 +448,7 @@ export default class Canvas extends Component<{
     //   can stay here), but for now since all key commands affect the canvas, this is fine.
     return (
       <HotKeys
-        style={{ flex: 1 }}
-        keyMap={this.keyMap}
+        style={{height: '100%'}}
         focused={true}
         attach={document.body}
         handlers={{handleTaskDelete: e => {


### PR DESCRIPTION
Control-z or Command-z will undo any task action just like pressing the Undo button
Control-shift-z or Command-shift-z will redo any task action just like pressing the Redo button.

I experimented with Control-y/Command-y for redo, but that's the Show History command on Chrome and I didn't want to override that completely.

Closes #207 