### PR TITLE
Add success message support in canvas to complement existing error messages

### DIFF
--- a/main.js
+++ b/main.js
@@ -142,8 +142,8 @@ class Window extends Component<{
               <Toolbar>
                 <ToolbarButton key="undo" icon="icon-redirect" errorMessage="Could not undo." onClick={() => undo()} />
                 <ToolbarButton key="redo" icon="icon-redirect2" errorMessage="Could not redo." onClick={() => redo()} />
-                <ToolbarButton key="rearrange" icon="icon-arrange" errorMessage="Error rearranging workflows." onClick={() => layout()} />
-                <ToolbarButton key="save" icon="icon-save" errorMessage="Error saving workflow." onClick={() => this.save()} />
+                <ToolbarButton key="rearrange" icon="icon-arrange" successMessage="Rearrange complete." errorMessage="Error rearranging workflows." onClick={() => layout()} />
+                <ToolbarButton key="save" icon="icon-save" successMessage="Workflow saved." errorMessage="Error saving workflow." onClick={() => this.save()} />
                 {
                   // TODO: Implement this.
                   // <ToolbarButton key="run" icon="icon-play" onClick={() => (undefined)} />

--- a/modules/st2flow-canvas/index.js
+++ b/modules/st2flow-canvas/index.js
@@ -38,7 +38,7 @@ type Wheel = WheelEvent & {
 }
 
 @connect(
-  ({ flow: { tasks, transitions, errors, nextTask, panels, navigation }}) => ({ tasks, transitions, errors, nextTask, isCollapsed: panels, navigation }),
+  ({ flow: { tasks, transitions, notifications, nextTask, panels, navigation }}) => ({ tasks, transitions, notifications, nextTask, isCollapsed: panels, navigation }),
   (dispatch) => ({
     issueModelCommand: (command, ...args) => {
       dispatch({
@@ -66,7 +66,7 @@ export default class Canvas extends Component<{
 
       tasks: Array<TaskInterface>,
       transitions: Array<Object>,
-      errors: Array<Error>,
+      notifications: Array<NotificationInterface>,
       issueModelCommand: Function,
       nextTask: string,
 
@@ -84,7 +84,7 @@ export default class Canvas extends Component<{
 
     tasks: PropTypes.array,
     transitions: PropTypes.array,
-    errors: PropTypes.array,
+    notifications: PropTypes.array,
     issueModelCommand: PropTypes.func,
     nextTask: PropTypes.string,
 
@@ -390,10 +390,10 @@ export default class Canvas extends Component<{
   }
 
   get notifications() : Array<NotificationInterface> {
-    return this.props.errors.map(err => ({
-      type: 'error',
-      message: err.message,
-    }));
+    return this.props.notifications;
+  }
+  get errors() : Array<NotificationInterface> {
+    return this.props.notifications.filter(n => n.type === 'error');
   }
 
   style = style
@@ -401,7 +401,7 @@ export default class Canvas extends Component<{
   surfaceRef = React.createRef();
 
   render() {
-    const { children, navigation, tasks=[], transitions=[], isCollapsed, toggleCollapse } = this.props;
+    const { notifications, children, navigation, tasks=[], transitions=[], isCollapsed, toggleCollapse } = this.props;
     const { scale } = this.state;
 
     const surfaceStyle = {
@@ -548,7 +548,7 @@ export default class Canvas extends Component<{
               </svg>
             </div>
           </div>
-          <Notifications position="bottom" notifications={this.notifications} />
+          <Notifications position="bottom" notifications={notifications} />
         </div>
       </HotKeys>
     );

--- a/modules/st2flow-canvas/toolbar.js
+++ b/modules/st2flow-canvas/toolbar.js
@@ -16,12 +16,18 @@ import style from './style.css';
         type: 'PUSH_ERROR',
         error,
       }),
+    pushSuccess: message =>
+      dispatch({
+        type: 'PUSH_SUCCESS',
+        message,
+      }),
   })
 )
 export class ToolbarButton extends Component<
   {
     icon: string,
     errorMessage?: string,
+    successMessage?: string,
     onClick: Function,
     pushError: Function
   },
@@ -32,6 +38,7 @@ export class ToolbarButton extends Component<
   static propTypes = {
     icon: PropTypes.string,
     errorMessage: PropTypes.string,
+    successMessage: PropTypes.string,
     onClick: PropTypes.func,
     pushError: PropTypes.func,
   };
@@ -47,13 +54,17 @@ export class ToolbarButton extends Component<
   async handleClick(e: Event) {
     e.stopPropagation();
 
-    const { onClick, errorMessage, pushError } = this.props;
+    const { onClick, errorMessage, successMessage, pushError, pushSuccess } = this.props;
 
     if (onClick) {
       this.setState({ status: 'pending' });
       try {
         await onClick();
         this.setState({ status: 'success' });
+
+        if (successMessage) {
+          pushSuccess(successMessage);
+        }
       }
       catch (e) {
         this.setState({ status: 'error' });

--- a/modules/st2flow-editor/index.js
+++ b/modules/st2flow-editor/index.js
@@ -2,6 +2,7 @@
 
 import type { TaskInterface, DeltaInterface } from '@stackstorm/st2flow-model';
 import type { GenericError } from '@stackstorm/st2flow-model';
+import type { NotificationInterface } from '@stackstorm/st2flow-notifications';
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -20,12 +21,12 @@ const DELTA_DEBOUNCE = 300; // ms
 const DEFAULT_TAB_SIZE = 2;
 
 @connect(
-  ({ ranges, errors }) => ({ ranges, errors })
+  ({ ranges, notifications }) => ({ ranges, notifications })
 )
 export default class Editor extends Component<{
   className?: string,
   ranges?: Object,
-  errors?: Array<Error>,
+  notifications?: Array<NotificationInterface>,
   selectedTaskName?: string,
   onTaskSelect?: Function,
   source?: string,
@@ -34,7 +35,7 @@ export default class Editor extends Component<{
   static propTypes = {
     className: PropTypes.string,
     ranges: PropTypes.object,
-    errors: PropTypes.array,
+    notifications: PropTypes.array,
     selectedTaskName: PropTypes.string,
     onTaskSelect: PropTypes.func,
     source: PropTypes.string,
@@ -67,7 +68,7 @@ export default class Editor extends Component<{
   }
 
   componentDidUpdate(prevProps: Object) {
-    const { selectedTaskName, source, errors } = this.props;
+    const { selectedTaskName, source, notifications } = this.props;
     if (selectedTaskName !== prevProps.selectedTaskName) {
       this.handleTaskSelect({ name: selectedTaskName });
     }
@@ -76,8 +77,8 @@ export default class Editor extends Component<{
       this.handleModelChange([], source);
     }
 
-    if (errors && errors !== prevProps.errors) {
-      this.handleModelError(errors);
+    if (notifications && notifications !== prevProps.notifications) {
+      this.handleModelError(notifications);
     }
   }
 
@@ -179,10 +180,10 @@ export default class Editor extends Component<{
   }
 
   get notifications() {
-    return this.props.errors && this.props.errors.map(err => ({
-      type: 'error',
-      message: err.message,
-    }));
+    return this.props.notifications;
+  }
+  get errors() {
+    return this.props.notifications ? this.props.notifications.filter(n => n.type === 'error') : [];
   }
 
 
@@ -195,7 +196,7 @@ export default class Editor extends Component<{
   style = style;
 
   render() {
-    const { errors } = this.props;
+    const { errors } = this;
 
     return (
       <div className={cx(this.props.className, this.style.component, { [this.style.hasError]: errors && errors.length })}>


### PR DESCRIPTION
Closes #198 

<img width="1069" alt="screen shot 2019-02-15 at 2 58 01 pm" src="https://user-images.githubusercontent.com/18686722/52889481-1a4d6280-314e-11e9-980c-7fc49fadb6ea.png">

Temporarily added a success message for rearranging, since save is still broken and run isn't supported yet.