### PR TITLE
Adding more helpful error for entry point missing

### DIFF
--- a/main.js
+++ b/main.js
@@ -104,6 +104,10 @@ class Window extends Component<{
       content: metaSource,
     }];
 
+    if (!meta.entry_point) {
+      throw { response: { data: { faultstring: 'You must add an Entry point.'}}};
+    }
+
     if (existingAction) {
       return api.request({ method: 'put', path: `/actions/${pack}.${meta.name}` }, meta);
     }


### PR DESCRIPTION
When the entry point is missing in meta data a cryptic response is given
by the API in the UI context. This PR adds a more appropriate error
when that parameter is not set.

Fixes #231 