### PR TITLE
Storing workflow as graph

### DIFF
--- a/modules/st2flow-graph/index.js
+++ b/modules/st2flow-graph/index.js
@@ -1,0 +1,125 @@
+import cytoscape from 'cytoscape';
+import _ from 'lodash';
+
+function edgeId(sourceId, destId) {
+  return `${sourceId}_${destId}`;
+}
+
+function checkGroup(item, type) {
+  const validTypes = [ 'nodes', 'edges' ];
+  if (!validTypes.includes(type)) {
+    throw 'Invalid type';
+  }
+  if (item.group() !== type) {
+    throw `Not of type ${type}`;
+  }
+}
+
+function updateElement(element, type, updates) {
+  checkGroup(element, type);
+  _.forEach(updates, (value, key) => {
+    element.data(key, value);
+    if (key === 'coords') {
+      element.position('x', value.x);
+      element.position('y', value.y);
+      element.position('z', value.z);
+    }
+  });
+}
+
+function getEdge(transitionData, graph) {
+  const source = graph.getElementById(transitionData.from.name);
+  const dest = graph.getElementById(transitionData.to[0].name);
+  const edge = graph.getElementById(edgeId(source.id(), dest.id()));
+  checkGroup(edge, 'edges');
+
+  return edge;
+}
+
+class Graph {
+  constructor() {
+    this.graph = cytoscape({ headless: true });
+  }
+
+  addTask(taskData) {
+    this.graph.add({
+      group: 'nodes',
+      data: {
+        id: taskData.name,
+        ...taskData,
+      },
+      position: {
+        x: taskData.coords.x,
+        y: taskData.coords.y,
+        z: taskData.coords.z,
+      },
+    });
+  }
+
+  updateTask(task, updates) {
+    const element = this.graph.getElementById(task.name);
+    updateElement(element, 'nodes', updates);
+  }
+
+  deleteTask(task) {
+    const element = this.graph.getElementById(task.name);
+    checkGroup(element, 'nodes');
+    element.remove();
+  }
+
+  addTransition(transitionData) {
+    const source = this.graph.getElementById(transitionData.from.name);
+    const dest = this.graph.getElementById(transitionData.to[0].name);
+
+    checkGroup(source, 'nodes');
+    checkGroup(dest, 'nodes');
+
+    if (!source || !dest) {
+      throw 'Task not found';
+    }
+
+    this.graph.add({
+      group: 'edges',
+      data: {
+        id: edgeId(source.id(), dest.id()),
+        source: source.id(),
+        target: dest.id(),
+      },
+    });
+  }
+
+  setTransitionProperty(transitionData, key, value) {
+    const edge = getEdge(transitionData, this.graph);
+    updateElement(edge, 'edges', { [key]: value });
+  }
+
+  deleteTransitionProperty(transitionData, key) {
+    const edge = getEdge(transitionData, this.graph);
+    edge.removeData(key);
+  }
+
+  deleteTransition(transitionData) {
+    const edge = getEdge(transitionData, this.graph);
+    edge.remove();
+  }
+
+  connections(sourceId) {
+    const source = this.graph.getElementById(sourceId);
+    checkGroup(source, 'nodes');
+
+    return _.map(source.connectedEdges(), (edge) => {
+      return edge.target().id(); 
+    });
+  }
+
+  edges(sourceId) {
+    const source = this.graph.getElementById(sourceId);
+    checkGroup(source, 'nodes');
+
+    return _.map(source.connectedEdges(), (edge) => {
+      return edge.id(); 
+    });
+  }
+}
+
+export default Graph;

--- a/modules/st2flow-graph/package.json
+++ b/modules/st2flow-graph/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@stackstorm/st2flow-graph",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stackstorm/st2flow.git"
+  },
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/stackstorm/st2flow/issues"
+  },
+  "homepage": "https://github.com/stackstorm/st2flow#readme",
+  "browserify": {
+    "transform": [
+      "babelify",
+      [
+        "@stackstorm/browserify-postcss",
+        {
+          "extensions": [
+            ".css"
+          ],
+          "inject": "insert-css",
+          "modularize": {
+            "camelCase": true
+          },
+          "plugin": [
+            "postcss-import",
+            "postcss-nested",
+            "postcss-color-mod-function",
+            "postcss-preset-env"
+          ]
+        }
+      ]
+    ]
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@stackstorm/st2flow-notifications": "^1.0.0",
+    "cytoscape": "^3.4.2",
+    "insert-css": "2.0.0",
+    "react-hotkeys": "^1.1.4"
+  },
+  "devDependencies": {
+    "@stackstorm/browserify-postcss": "0.3.4-patch.5",
+    "babelify": "8.0.0",
+    "classnames": "^2.2.6",
+    "postcss": "6.0.22",
+    "postcss-color-mod-function": "^2.4.3",
+    "postcss-import": "11.1.0",
+    "postcss-nested": "3.0.0",
+    "postcss-preset-env": "5.1.0"
+  }
+}

--- a/store.js
+++ b/store.js
@@ -1,11 +1,13 @@
 import { createScopedStore } from '@stackstorm/module-store';
 
 import { models, OrquestaModel } from '@stackstorm/st2flow-model';
+import Graph from '@stackstorm/st2flow-graph';
 import { layout } from '@stackstorm/st2flow-model/layout';
 import MetaModel from '@stackstorm/st2flow-model/model-meta';
 
 let workflowModel = new OrquestaModel();
 const metaModel = new MetaModel();
+const graph = new Graph();
 
 function workflowModelGetter(model) {
   const { tasks, transitions, errors } = model;
@@ -86,8 +88,17 @@ const flowReducer = (state = {}, input) => {
     case 'MODEL_ISSUE_COMMAND': {
       const { command, args } = input;
 
+      console.log(command);
+
       if (!workflowModel[command]) {
         return state;
+      }
+
+      if (graph[command]) {
+        graph[command](...args);
+      }
+      else{
+        console.log(`No graph function for ${command}`);
       }
 
       if (!workflowModel.tokenSet) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2793,6 +2793,14 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
+cytoscape@^3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.4.2.tgz#f35f0d4a8ccb5901e801046230edccf1c3a39806"
+  integrity sha512-+n10uc/MIs+XWsXff8M2zfA681E9O41bLgwAKP9IsBNckqQMWQQP6cRBjeJYUZwm6MigF4GGWdBUlmX4Ef+8WQ==
+  dependencies:
+    heap "^0.2.6"
+    lodash.debounce "^4.0.8"
+
 d@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
@@ -4634,6 +4642,11 @@ he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
+heap@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac"
+  integrity sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=
+
 history@^4.7.2:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
@@ -5640,7 +5653,7 @@ lodash.assign@^3.2.0:
     lodash._createassigner "^3.0.0"
     lodash.keys "^3.0.0"
 
-lodash.debounce@^4.0.6:
+lodash.debounce@^4.0.6, lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 


### PR DESCRIPTION
This PR starts the process of transitioning to graph as single source of truth.

## Motivation
Current source of truth is a combination of YAML and state. To allow easier abstractions and keep things as DRY as possible having the single source of truth be a graph will allow us to maintain clean abstractions to the YAML rendering for the spec of choice.

This PR will include
- [x] Basic graph implementation
- [x] Canvas -> graph storage
- [ ] Graph -> Mistral YAML conversion