### PR TITLE
Fix runner_type switch

### DIFF
--- a/modules/st2-auto-form/fields/enum.js
+++ b/modules/st2-auto-form/fields/enum.js
@@ -25,8 +25,7 @@ export default class EnumField extends BaseTextField {
   }
 
   render() {
-    const { spec={} } = this.props;
-    const { invalid } = this.state;
+    const { spec={}, invalid } = this.props;
 
     const wrapperProps = Object.assign({}, this.props, {
       labelClass: 'st2-auto-form__select',
@@ -39,11 +38,11 @@ export default class EnumField extends BaseTextField {
     const selectProps = {
       className: 'st2-auto-form__field',
       disabled: this.props.disabled,
-      value: this.state.value,
+      value: this.props.value,
       onChange: (e) => this.handleChange(e, e.target.value),
     };
 
-    if (this.state.invalid) {
+    if (invalid) {
       selectProps.className += ' ' + 'st2-auto-form__field--invalid';
     }
 

--- a/modules/st2flow-details/meta-panel.js
+++ b/modules/st2flow-details/meta-panel.js
@@ -19,11 +19,21 @@ import Parameters from './parameters-panel';
       type: 'CHANGE_NAVIGATION',
       navigation,
     }),
-    setMeta: (field, value) => dispatch({
-      type: 'META_ISSUE_COMMAND',
-      command: 'set',
-      args: [ field, value ],
-    }),
+    setMeta: (field, value) => {
+      try{
+        dispatch({
+          type: 'META_ISSUE_COMMAND',
+          command: 'set',
+          args: [ field, value ],
+        });
+      }
+      catch(error) {
+        dispatch({
+          type: 'PUSH_ERROR',
+          error,
+        });
+      }
+    },
     setPack: (pack) => dispatch({
       type: 'SET_PACK',
       pack,

--- a/store.js
+++ b/store.js
@@ -115,6 +115,10 @@ const flowReducer = (state = {}, input) => {
     case 'META_ISSUE_COMMAND': {
       const { command, args } = input;
 
+      if (command === 'set' && args[0] === 'runner_type' && state.tasks.length > 0) {
+        throw 'Cannot change runner_type of workflow that has existing tasks';
+      }
+
       if (!metaModel[command]) {
         return state;
       }
@@ -129,11 +133,8 @@ const flowReducer = (state = {}, input) => {
       if (runner_type && runner_type !== meta.runner_type) {
         const Model = models[runner_type];
 
-        workflowModel = new Model(workflowSource);
-
-        if (!workflowModel.tokenSet) {
-          workflowModel.fromYAML(workflowModel.constructor.minimum);
-        }
+        workflowModel = new Model();
+        workflowModel.fromYAML(workflowModel.constructor.minimum);
 
         state = {
           ...state,


### PR DESCRIPTION
When selecting between different runner_types there were several bugs
preventing successful switch. This PR prevents switching if any
tasks have been added to the workflow and corrects enum form filed to pull
from props instead of state.

Fixes #247 

TODO:
- [x] Ensure changes don't break loading workflow
- [ ] Tests for above