### PR TITLE
Fix the display of the dropdowns for the next task in a transition

### DIFF
--- a/modules/st2-auto-form/fields/select.js
+++ b/modules/st2-auto-form/fields/select.js
@@ -38,14 +38,16 @@ export default class SelectField extends BaseTextField {
     }
 
     return (
-      <select {...selectProps}>
-        { spec.default ? null : (
-          <option value='' />
-        ) }
-        { _.map(spec.options, (o) => (
-          <option key={o.value} value={o.value}>{ o.text }</option>
-        ) ) }
-      </select>
+      <div className="st2-auto-form__select">
+        <select {...selectProps}>
+          { spec.default ? null : (
+            <option value='' />
+          ) }
+          { _.map(spec.options, (o) => (
+            <option key={o.value} value={o.value}>{ o.text }</option>
+          ) ) }
+        </select>
+      </div>
     );
   }
 }

--- a/modules/st2flow-details/mistral-transition.js
+++ b/modules/st2flow-details/mistral-transition.js
@@ -7,7 +7,7 @@ import { PropTypes } from 'prop-types';
 import { connect } from 'react-redux';
 import cx from 'classnames';
 
-import { StringField, EnumField, ColorStringField } from '@stackstorm/module-auto-form/fields';
+import { StringField, SelectField, ColorStringField } from '@stackstorm/module-auto-form/fields';
 
 import style from './style.css';
 
@@ -85,6 +85,7 @@ export default class MistralTransition extends Component<TransitionProps, {}> {
   render() {
     const { transition, taskNames, selected } = this.props;
     const [ to ] = transition.to.map(t => t.name);
+    const taskOptions = taskNames.map(n => ({ text: n, value: n }));
     const colorOptions = [ '#fecb2f', '#d1583b', '#aa5dd1', '#629e47', '#fd9d32', '#d14c83', '#5b5dd0', '#1072c6' ];
 
     return (
@@ -103,7 +104,7 @@ export default class MistralTransition extends Component<TransitionProps, {}> {
             Do
           </div>
           <div className={this.style.transitionField}>
-            <EnumField value={to} spec={{ enum: taskNames }} onChange={v => this.handleDoChange(v)} />
+            <SelectField value={to} spec={{ default: true, options: taskOptions }} onChange={v => this.handleDoChange(v)} />
           </div>
         </div>
         <div className={this.style.transitionLine} >


### PR DESCRIPTION
Closes #188

Fix the display of selects (not using native browser styling which is a bit outdated looking on Firefox), by ensuring that the select auto form widget supplies the containing class that styles the select element correctly.

![image](https://user-images.githubusercontent.com/18686722/53922786-c1cdfe80-4043-11e9-9b4c-ef042bb5c57c.png)

Also have mistral transition details use the select field instead of the enum field to unify display and behavior with orquesta.