### PR TITLE
Render nulls in YAML as empty fields for Object field types, instead of empty object

### DIFF
--- a/modules/st2-auto-form/fields/object.js
+++ b/modules/st2-auto-form/fields/object.js
@@ -17,7 +17,7 @@ export default class ObjectField extends BaseTextareaField {
       return v;
     }
 
-    return JSON.stringify(v || {}, null, 2);
+    return v === null ? '' : JSON.stringify(v || {}, null, 2);
   }
 
   validate(v, spec) {


### PR DESCRIPTION
Closes #257 

The sequence of output into an object field in 257 was due to state transitions in the YAML store:

- default of `{}` corresponded to the key not existing in the yaml (effectively undefined)
- Deleting to `{` failed validation, no change to yaml
- Deleting to empty set the value to `null`, which was also causing the field to default to `{}`
- Deleting to `{` failed validation again.
- Deleting to empty the second time made no change to the YAML (the value was still null), so no change listeners were fired.

To fix this, when an object field in the YAML is null, it now corresponds to an empty _field_, rather than the default empty _object_ stringifying to `{}`.  Undefined still corresponds to the default empty object.