### PR TITLE
Better UX for Join property in Task details

### DIFF
--- a/modules/st2flow-canvas/task.js
+++ b/modules/st2flow-canvas/task.js
@@ -259,10 +259,10 @@ export class Task extends Component<{
                   )
                 }
                 {
-                  task.join && (
+                  !!task.join && (
                     <span className={cx(this.style.taskBadge)}>
                       <i className={cx(this.style.taskBadgeJoin)} />
-                      {+task.join ? task.join : ''}
+                      {typeof task.join === 'number' ? task.join : '​\u200B'}
                     </span>
                   )
                 }

--- a/modules/st2flow-details/mistral-properties.js
+++ b/modules/st2flow-details/mistral-properties.js
@@ -55,10 +55,10 @@ export default class MistralProperties extends Component<TransitionProps, {}> {
     issueModelCommand: PropTypes.func,
   }
 
-  handleTaskProperty(name: string | Array<string>, value: any) {
+  handleTaskProperty(name: string | Array<string>, value: any, noDelete: boolean = false) {
     const { task, issueModelCommand } = this.props;
 
-    if (value !== undefined) {
+    if (value || noDelete) {
       issueModelCommand && issueModelCommand('setTaskProperty', task, name, value);
     }
     else {
@@ -73,15 +73,26 @@ export default class MistralProperties extends Component<TransitionProps, {}> {
     const { task } = this.props;
 
     return [
-      <Property key="join" name="Join" description="Allows to synchronize multiple parallel workflow branches and aggregate their data."  value={!!task.join} onChange={value => this.handleTaskProperty('join', value !== false ? 'all' : undefined)}>
+      <Property key="join" name="Join" description="Allows to synchronize multiple parallel workflow branches and aggregate their data."  value={task.join != null} onChange={value => this.handleTaskProperty('join', value !== false ? 'all' : undefined)}>
         {
-          task.join !== undefined && (
+          task.join != null && (
             <div className={cx(this.style.propertyChild, this.style.radioGroup)}>
               <div className={cx(this.style.radio, task.join === 'all' && this.style.checked)} onClick={() => this.handleTaskProperty('join', 'all')}>
                 Join all tasks
               </div>
               <label htmlFor="joinField" className={cx(this.style.radio, task.join !== 'all' && this.style.checked)} onClick={(e) => this.handleTaskProperty('join', parseInt((this.joinFieldRef.current || {}).value, 10))} >
-                Join <input type="text" id="joinField" size="3" className={this.style.radioField} ref={this.joinFieldRef} value={isNaN(task.join) ? 10 : task.join} onChange={e => this.handleTaskProperty('join', parseInt(e.target.value, 10))} /> tasks
+                Join
+                <input
+                  type="text"
+                  id="joinField"
+                  size="3"
+                  className={this.style.radioField}
+                  ref={this.joinFieldRef}
+                  value={isNaN(task.join) ? 10 : task.join}
+                  onChange={e => this.handleTaskProperty('join', parseInt(e.target.value, 10) || 0, true)}
+                  onBlur={e => this.handleTaskProperty('join', parseInt(e.target.value, 10))}
+                />
+                tasks
               </label>
             </div>
           )

--- a/modules/st2flow-details/orquesta-properties.js
+++ b/modules/st2flow-details/orquesta-properties.js
@@ -36,10 +36,10 @@ export default class OrquestaTransition extends Component<TransitionProps, {}> {
     issueModelCommand: PropTypes.func,
   }
 
-  handleTaskProperty(name: string | Array<string>, value: any) {
+  handleTaskProperty(name: string | Array<string>, value: any, noDelete: boolean = false) {
     const { task, issueModelCommand } = this.props;
 
-    if (value) {
+    if (value || noDelete) {
       issueModelCommand && issueModelCommand('setTaskProperty', task, name, value);
     }
     else {
@@ -54,15 +54,32 @@ export default class OrquestaTransition extends Component<TransitionProps, {}> {
     const { task } = this.props;
 
     return [
-      <Property key="join" name="Join" description="Allows to synchronize multiple parallel workflow branches and aggregate their data."  value={!!task.join} onChange={value => this.handleTaskProperty('join', value ? 'all' : false)}>
+      <Property
+        key="join"
+        name="Join"
+        description="Allows to synchronize multiple parallel workflow branches and aggregate their data."
+        value={task.join != null}
+        onChange={value => this.handleTaskProperty('join', value ? 'all' : false)}
+      >
         {
-          task.join && (
+          task.join != null && (
             <div className={cx(this.style.propertyChild, this.style.radioGroup)}>
               <div className={cx(this.style.radio, task.join === 'all' && this.style.checked)} onClick={() => this.handleTaskProperty('join', 'all')}>
                 Join all tasks
               </div>
               <label htmlFor="joinField" className={cx(this.style.radio, task.join !== 'all' && this.style.checked)} onClick={(e) => this.handleTaskProperty('join', parseInt((this.joinFieldRef.current || {}).value, 10))} >
-                Join <input type="text" id="joinField" size="3" className={this.style.radioField} ref={this.joinFieldRef} value={isNaN(task.join) ? 10 : task.join} onChange={e => this.handleTaskProperty('join', parseInt(e.target.value, 10))} /> tasks
+                Join
+                <input
+                  type="text"
+                  id="joinField"
+                  size="3"
+                  className={this.style.radioField}
+                  ref={this.joinFieldRef}
+                  value={isNaN(task.join) ? 10 : task.join}
+                  onChange={e => this.handleTaskProperty('join', parseInt(e.target.value, 10) || 0, true)}
+                  onBlur={e => this.handleTaskProperty('join', parseInt(e.target.value, 10))}
+                />
+                tasks
               </label>
             </div>
           )


### PR DESCRIPTION
Closes #255 

If the number of items field is cleared or set to zero, don't immediately switch off join.  Instead wait until blur to delete the join property in the YAML and thus turn off the switch.

![ST2FLOW-255](https://user-images.githubusercontent.com/18686722/54319189-20a0f400-45bf-11e9-88b4-49c81f33dcaf.gif)
