### PR TITLE
Show With Items badge in canvas for Mistral Tasks.

### DIFF
--- a/modules/st2flow-canvas/task.js
+++ b/modules/st2flow-canvas/task.js
@@ -251,7 +251,7 @@ export class Task extends Component<{
               <div className={cx(this.style.taskAction)}>{task.action}</div>
               <div className={cx(this.style.taskBadges)}>
                 {
-                  task.with && (
+                  !!task.with && (
                     <span className={cx(this.style.taskBadge)}>
                       <i className={cx(this.style.taskBadgeWithItems)} />
                       { task.with && +task.with.concurrency ? task.with.concurrency : ''}

--- a/modules/st2flow-details/mistral-properties.js
+++ b/modules/st2flow-details/mistral-properties.js
@@ -66,6 +66,7 @@ export default class MistralProperties extends Component<TransitionProps, {}> {
     }
   }
 
+
   style = style
   joinFieldRef = React.createRef();
 

--- a/modules/st2flow-model/model-mistral.js
+++ b/modules/st2flow-model/model-mistral.js
@@ -114,6 +114,11 @@ export default class MistralModel extends BaseModel implements ModelInterface {
         'with-items': restTask['with-items'],
         join: restTask.join,
         concurrency: restTask.concurrency,
+        // for TaskInterface
+        with: restTask['with-items'] ? {
+          items: restTask['with-items'],
+          concurrency: (restTask.concurrency || '').toString(),
+        } : void 0,
         'pause-before': restTask['pause-before'],
         'wait-before': restTask['wait-before'],
         'wait-after': restTask['wait-after'],


### PR DESCRIPTION
Closes #261 

This required adding a `with` property to the mistral model tasks, combining with-items and concurrency.  The original with-items and concurrency fields are preserved.

![image](https://user-images.githubusercontent.com/18686722/54319322-97d68800-45bf-11e9-97dd-8892e4f6d053.png)
