### PR TITLE
Don't overwrite a token's comments if there's no old first item available

### DIFF
--- a/modules/st2flow-yaml/crawler.js
+++ b/modules/st2flow-yaml/crawler.js
@@ -155,7 +155,9 @@ const crawler = {
         parentToken.value = factory.createToken(value, { escape: true });
 
         const newFirst = this.findFirstValueToken(parentToken.value);
-        newFirst.prefix = oldFirst && oldFirst.prefix;
+        if(oldFirst) {
+          newFirst.prefix = oldFirst.prefix;
+        }
         tokenSet.refineTree();
         break;
       }


### PR DESCRIPTION
This bug affected the placement of mistral tasks that were dragged into the canvas by the user.  The YAML crawler was replacing the comments of the token representing that task with nothing since there was no "old first" token in that collection.

Closes #260 