### PR TITLE
Make the icon boxes for text field types both visible and non-responsive to pointer events

### DIFF
--- a/modules/st2-auto-form/fields/array.js
+++ b/modules/st2-auto-form/fields/array.js
@@ -49,7 +49,7 @@ function split(value) {
 }
 
 export default class ArrayField extends BaseTextField {
-  static icon = '[ ]'
+  static icon = 'brackets'
 
   fromStateValue(v) {
     if (v === '') {

--- a/modules/st2-auto-form/fields/color-string.js
+++ b/modules/st2-auto-form/fields/color-string.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import StringField from './string';
 import { Label, Icon, ErrorMessage, Description, Title } from '../wrappers';
 export default class ColorStringField extends StringField {
+  static icon = 'V';
+
   static propTypes = {
     name: PropTypes.string,
     spec: PropTypes.object,
@@ -42,7 +44,7 @@ export default class ColorStringField extends StringField {
       <div className="st2-auto-form__select">
         <div className='st2-auto-form__line'>
           <Label className={this.props.labelClass || 'st2-auto-form__text-field'}>
-            {options && <Icon name={icon} onClick={() => this.setState({ open: !open })} />}
+            {options && <Icon name={icon} style={{pointerEvents:'initial'}} onClick={() => this.setState({ open: !open })} />}
             <Title {...this.props} />
             <span className="st2-auto-form__field-color-block" style={{backgroundColor: value}}>&nbsp;</span>
             <input {...inputProps} />

--- a/modules/st2-auto-form/fields/enum.js
+++ b/modules/st2-auto-form/fields/enum.js
@@ -29,6 +29,7 @@ export default class EnumField extends BaseTextField {
 
     const wrapperProps = Object.assign({}, this.props, {
       labelClass: 'st2-auto-form__select',
+      icon: this.constructor.icon,
     });
 
     if (invalid) {

--- a/modules/st2-auto-form/fields/object.js
+++ b/modules/st2-auto-form/fields/object.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { BaseTextareaField, isJinja } from './base';
 
 export default class ObjectField extends BaseTextareaField {
-  static icon = '{ }'
+  static icon = 'braces'
 
   fromStateValue(v) {
     if (isJinja(v)) {

--- a/modules/st2-auto-form/style.css
+++ b/modules/st2-auto-form/style.css
@@ -40,7 +40,7 @@
   &__type {
     font-size: 18px;
     font-weight: normal;
-    line-height: 38px;
+    line-height: 31px;
 
     position: absolute;
     right: 0;
@@ -52,6 +52,8 @@
     text-align: center;
 
     color: var(--grey-base);
+    opacity: 0.5;
+    pointer-events: none;
   }
 
   &__button {
@@ -232,28 +234,6 @@
 
   &__select {
     position: relative;
-
-    &:after {
-      font-family: "st2";
-      font-size: 18px;
-      font-weight: normal;
-      font-style: normal;
-      line-height: 32px;
-
-      position: absolute;
-      right: 0;
-      bottom: 0;
-
-      display: block;
-
-      padding: 0 10px 0 0;
-
-      content: "\e91c";
-      vertical-align: middle;
-      pointer-events: none;
-
-      color: black;
-    }
   }
 
   &__select &__field {
@@ -474,4 +454,62 @@
 
 .st2-manual-form {
   position: relative;
+}
+
+.icon-T {
+  &:before {
+    content: 'T';
+    font-family: Garamond, Georgia, Times New Roman, serif !important;;
+  }
+}
+
+.icon-braces {
+  &:before {
+    width: 2em !important;
+    content: '{ }';
+    font-family: Garamond, Georgia, Times New Roman !important;
+  }
+}
+
+.icon-brackets {
+  &:before {
+    width: 2em !important;
+    content: '[ ]';
+    font-family: Garamond, Georgia, Times New Roman !important;
+  }
+}
+
+.icon-12 {
+  &:before {
+    content: '\1D7D9';
+    font-family: Helvetica, Arial !important;
+  }
+}
+
+.icon-\.5 {
+  &:before {
+    content: '\1D7D9.\1D7D8';
+    font-family: Helvetica, Arial !important;
+  }
+}
+
+.icon-\*\* {
+  &:before {
+    content: '***';
+    font-family: Helvetica, Arial !important;
+  }
+}
+
+.icon-V {
+  color: black;
+  opacity: 1;
+  &:before {
+    font-family: "st2";
+    font-size: 18px;
+    font-weight: normal;
+    font-style: normal;
+
+    content: "\e91c";
+    vertical-align: middle;
+  }
 }

--- a/modules/st2-auto-form/wrappers.js
+++ b/modules/st2-auto-form/wrappers.js
@@ -163,8 +163,8 @@ export class TextFieldWrapper extends React.Component {
     const line = (
       <div className='st2-auto-form__line'>
         <Label className={this.props.labelClass || 'st2-auto-form__text-field'}>
-          <Icon name={this.props.icon} />
           <Title {...this.props} />
+          <Icon name={this.props.icon} />
           { this.props.children }
           <ErrorMessage>{ this.props.invalid }</ErrorMessage>
         </Label>


### PR DESCRIPTION
Closes #258, which was an issue where the boxes interfered with clicking to focus the fields.

In addition, I've added content to these icon boxes to reflect the contents of the respective text fields:

![image](https://user-images.githubusercontent.com/18686722/54571564-b373d100-49b9-11e9-9695-79175aa98e3b.png)
