### PR TITLE
Only copy yaml prefixes when both old and new first value tokens exist

### DIFF
--- a/modules/st2flow-yaml/crawler.js
+++ b/modules/st2flow-yaml/crawler.js
@@ -155,7 +155,7 @@ const crawler = {
         parentToken.value = factory.createToken(value, { escape: true });
 
         const newFirst = this.findFirstValueToken(parentToken.value);
-        if(oldFirst) {
+        if(newFirst && oldFirst) {
           newFirst.prefix = oldFirst.prefix;
         }
         tokenSet.refineTree();


### PR DESCRIPTION
Fixes the case when trying to delete the last parameter in mistral workflows would cause an error to be thrown.

Closes #280 
