### PR TITLE
stop building bionic packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     machine: true
     environment:
       DEPLOY_PACKAGES: 1
-      DEB: trusty xenial bionic
+      DEB: trusty xenial
       RPM: el6 el7
       ST2_HOST: localhost
       ST2_USERNAME: admin
@@ -144,7 +144,6 @@ jobs:
           paths:
             - trusty
             - xenial
-            - bionic
             - el6
             - el7
 
@@ -153,7 +152,7 @@ jobs:
       - image: ruby:2.4.4
     environment:
       ARTIFACTS: /home/circleci/artifacts
-      DISTROS: trusty xenial bionic el6 el7
+      DISTROS: trusty xenial el6 el7
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
somehow we were still building bionic packages for st2flow.

We never promoted them past enterprise-staging-unstable. But still seems unnecessary to build them in the first place