### PR TITLE
Enable workflow by default

### DIFF
--- a/modules/st2flow-model/model-meta.js
+++ b/modules/st2flow-model/model-meta.js
@@ -8,7 +8,7 @@ class MetaModel extends BaseClass {
     super(schema, yaml);
   }
 
-  static minimum = 'pack: default\n';
+  static minimum = 'pack: default\nenabled: true\n';
 
   get name(): string {
     return this.get('name');


### PR DESCRIPTION
This PR adds `enabled: true` to the default meta-data. This will
enable the workflow by default and hopefully prevent users from being
confused when the go to execute recently added workflows.

Fixes #321