### PR TITLE
Pack not installed warning

### DIFF
--- a/modules/st2flow-details/task-details.js
+++ b/modules/st2flow-details/task-details.js
@@ -204,6 +204,7 @@ export default class TaskDetails extends Component<TaskDetailsProps, {
       </Toolbar>,
       section === 'input' && (
         <Panel key="input">
+          {!action && <p>Couldn&apos;t find action. Is the pack installed?</p>}
           <AutoForm
             spec={{
               type: 'object',


### PR DESCRIPTION
This PR adds a conditional message to the parameters panel. If the
action is not found it communicates this to the user and asks them to
double-check if the pack is installed.

Fixes #329 