### PR TITLE
Allow commented tasks

### DIFF
--- a/modules/st2flow-model/model-mistral.js
+++ b/modules/st2flow-model/model-mistral.js
@@ -328,7 +328,10 @@ export default class MistralModel extends BaseModel implements ModelInterface {
     }
 
     if (coords) {
-      const comments = crawler.getCommentsForKey(this.tokenSet, key) || '[0, 0]';
+      let comments = crawler.getCommentsForKey(this.tokenSet, key) || '[0, 0]';
+      if (!REG_COORDS.test(comments)) {
+        comments += '\n[0, 0]';
+      }
       crawler.setCommentForKey(this.tokenSet, key, comments.replace(REG_COORDS, `[${coords.x.toFixed()}, ${coords.y.toFixed()}]`));
     }
 

--- a/modules/st2flow-model/model-orquesta.js
+++ b/modules/st2flow-model/model-orquesta.js
@@ -323,7 +323,11 @@ class OrquestaModel extends BaseModel implements ModelInterface {
     }
 
     if (coords) {
-      const comments = crawler.getCommentsForKey(this.tokenSet, key) || '[0, 0]';
+      let comments = crawler.getCommentsForKey(this.tokenSet, key) || '[0, 0]';
+      // crawler.setCommentForKey(this.tokenSet, key, `[${coords.x.toFixed()}, ${coords.y.toFixed()}]`);
+      if (!REG_COORDS.test(comments)) {
+        comments += '\n[0, 0]';
+      }
       crawler.setCommentForKey(this.tokenSet, key, comments.replace(REG_COORDS, `[${coords.x.toFixed()}, ${coords.y.toFixed()}]`));
     }
 


### PR DESCRIPTION
This PR adds a check to mistral/orquesta model to allow for tasks
with comments to have coordinates appended to the comment block.
Previously the app would crash if there was a comment block with no
coordinates.

Fixes #331 