### PR TITLE
Fix rpm warning during st2flow package install/upgrade

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -13,7 +13,7 @@ angular.module('main').run(
 EHD
 )
 
-jsinject_flaw() {
+jsinject_flow() {
   [ -f "$WEBUI_CONFIGJS" ] || { echo "St2web \`${WEBUI_CONFIGJS}' not found"; exit 1; }
   # configuration has been already injected (might be by hand), so return
   grep -q "st2Config.flow\\s\+=\\s\+" $WEBUI_CONFIGJS && return 0 || :
@@ -22,7 +22,7 @@ jsinject_flaw() {
 
 case "$1" in
     configure)
-      jsinject_flaw
+      jsinject_flow
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
     ;;

--- a/rpm/postinst_script.spec
+++ b/rpm/postinst_script.spec
@@ -12,11 +12,11 @@ angular.module('main').run(
 EHD
 )
 
-jsinject_flaw() {
+jsinject_flow() {
   [ -f "$WEBUI_CONFIGJS" ] || { echo "St2web \`${WEBUI_CONFIGJS}' not found"; exit 1; }
   # configuration has been already injected (might be by hand), so return
   grep -q "st2Config.flow\\s\+=\\s\+" $WEBUI_CONFIGJS && return 0 || :
   echo "$FLOW_CONFIG" >> $WEBUI_CONFIGJS
 }
 
-jsinject_flaw
+jsinject_flow


### PR DESCRIPTION
```
  Updating   : st2flow-3.0dev-44.x86_64                                                                                                                                                           54/125
/var/tmp/rpm-tmp.9c0sKD: line 17: return: can only `return' from a function or sourced script
```

Closes https://github.com/StackStorm/ewc/issues/8