### PR TITLE
Fixing mistral variables

### DIFF
--- a/modules/st2flow-model/model-mistral.js
+++ b/modules/st2flow-model/model-mistral.js
@@ -93,13 +93,17 @@ export default class MistralModel extends BaseModel implements ModelInterface {
   }
 
   get vars() {
-    let val;
+    const val = [];
     const workflows = getWorkflows(this.tokenSet);
     Object.keys(workflows).some(wfName => {
       const workflow = workflows[ wfName ];
 
       if(workflow.vars) {
-        val = workflow.vars;
+        Object.keys(workflow.vars).map(key => {
+          const newVar = {};
+          newVar[key] = workflow.vars[key];
+          val.push(newVar);
+        });
         return true; // break
       }
 
@@ -244,9 +248,15 @@ export default class MistralModel extends BaseModel implements ModelInterface {
   setVars(vars: Array<Object>) {
     const { oldTree } = this.startMutation();
     const workflows = getWorkflows(this.tokenSet);
+    const objectVars = {};
+    vars.forEach(varInstance => {
+      Object.keys(varInstance).map(key => {
+        objectVars[key] = varInstance[key];
+      });
+    });
     Object.keys(workflows).forEach(wfName => {
       if (vars && vars.length) {
-        crawler.set(this.tokenSet, [ wfName, 'vars' ], vars);
+        crawler.set(this.tokenSet, [ wfName, 'vars' ], objectVars);
       }
       else {
         crawler.delete(this.tokenSet, [ wfName, 'vars' ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1603,7 +1603,7 @@
     sinon-chai "3.3.0"
     zombie "5.0.8"
 
-"@stackstorm/st2-build@^2.4.1", "@stackstorm/st2-build@^2.4.2":
+"@stackstorm/st2-build@^2.4.2":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@stackstorm/st2-build/-/st2-build-2.4.2.tgz#9fbf0bf63b2e3d3e81bf50d343784cf60800f0e4"
   integrity sha512-t6HogTUhx7LtXkPNMTjtTjjsds6tVz4kWG8nuBiLBxNc6isJ8y/i87H8J159HbUbUK1BYPfQSr+Dx0sIQJqrJQ==
@@ -4090,7 +4090,7 @@ escodegen@~1.9.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-plugin-flowtype@^3.4.2, eslint-plugin-flowtype@^3.5.1:
+eslint-plugin-flowtype@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.5.1.tgz#903c542c33039bc1db16355fff2d26733903bb0b"
   integrity sha512-mIhq7jhBSWNMp3ECmlWK+b9EFmLE+3Jd9axk05LB+snbRPkc3/lYTgb4Bu9lgt1QLmrxFDWsASdKj9CAIehckg==


### PR DESCRIPTION
Mistral variables are a pure object, while orquesta variables are a list
of objects with a single key. The original var functionality was built
around orquesta and assumed mistral handled vars the same way. This
PR fixes the incorrect handling of mistral vars by parsing the list
of objects into a flat object and visa-versa for loading.

Closes #345 