### PR TITLE
Set pack in meta file

### DIFF
--- a/modules/st2flow-details/meta-panel.js
+++ b/modules/st2flow-details/meta-panel.js
@@ -45,10 +45,25 @@ const default_runner_type = 'orquesta';
         args: [ value ],
       });
     },
-    setPack: (pack) => dispatch({
-      type: 'SET_PACK',
-      pack,
-    }),
+    setPack: (pack) => {
+      dispatch({
+        type: 'SET_PACK',
+        pack,
+      });
+      try{
+        dispatch({
+          type: 'META_ISSUE_COMMAND',
+          command: 'set',
+          args: [ 'pack', pack ],
+        });
+      }
+      catch(error) {
+        dispatch({
+          type: 'PUSH_ERROR',
+          error,
+        });
+      }
+    },
   })
 )
 export default class Meta extends Component<{


### PR DESCRIPTION
Current implementation does not set pack in pack metadata when it is
selected. This PR dispatches to metadata reducer in addition to
set_pack reducer so that it actually gets set in metadata.

Fixes #347 