### PR TITLE
Don't crash on mistral workbook

### DIFF
--- a/modules/st2flow-model/model-mistral.js
+++ b/modules/st2flow-model/model-mistral.js
@@ -50,8 +50,15 @@ export default class MistralModel extends BaseModel implements ModelInterface {
 
   static minimum = 'version: \'2.0\'\nmain:\n  tasks: {}\n';
 
+  #workbook;
+
   constructor(yaml: ?string) {
     super(schema, yaml);
+    this.#workbook = this.tokenSet.toObject().workflows ? true : false;
+
+    if (this.#workbook) {
+      this.emitError(new Error('Mistral workbooks are not supported.'));
+    }
   }
 
   get description() {
@@ -541,7 +548,14 @@ export default class MistralModel extends BaseModel implements ModelInterface {
 
   getRangeForTask(task: TaskRefInterface) {
     const [ workflowName, taskName ] = splitTaskName(task.name, this.tokenSet);
-    return crawler.getRangeForKey(this.tokenSet, [ workflowName, 'tasks', taskName ]);
+    const key = [];
+    if (this.#workbook) {
+      key.push('workflows');
+    }
+    key.push(workflowName);
+    key.push('tasks');
+    key.push(taskName);
+    return crawler.getRangeForKey(this.tokenSet, key);
   }
 }
 

--- a/modules/st2flow-model/schemas/mistral.json
+++ b/modules/st2flow-model/schemas/mistral.json
@@ -6,11 +6,6 @@
   "title": "Mistral Schema",
   "description": "A schema describing Mistral workflows and workbooks.",
   "type": "object",
-  "dependencies": {
-    "workflows": {
-      "additionalProperties": false
-    }
-  },
   "patternProperties": {
     "^(?!version)\\w+$": {
       "$ref": "#/definitions/workflow"


### PR DESCRIPTION
Despite not currently support mistral workbooks flow should not crash
when a workbook is loaded. This PR adds a check for workbooks and if
it is a workbook we emit a message to notify the user that we do not
currently support workbook. It also adds minor changes to the path
rendering to ensure that the workflow visualization can load.

Related to #346 