### PR TITLE
fix for charter bug

### DIFF
--- a/modules/st2-auto-form/fields/object.js
+++ b/modules/st2-auto-form/fields/object.js
@@ -4,11 +4,11 @@
 // prohibited. Proprietary and confidential. See the LICENSE file
 // included with this work for details.
 
-import _ from "lodash";
-import { BaseTextareaField, isJinja } from "./base";
+import _ from 'lodash';
+import { BaseTextareaField, isJinja } from './base';
 
 export default class ObjectField extends BaseTextareaField {
-  static icon = "braces";
+  static icon = 'braces';
 
   fromStateValue(v) {
     if (isJinja(v)) {
@@ -16,9 +16,11 @@ export default class ObjectField extends BaseTextareaField {
     }
 
     // check if object is valid
-    if (!_.isPlainObject(o)) return 0;
+    if (!_.isPlainObject(v)) {
+      return 0;
+    }
 
-    return v !== "" && v !== undefined ? JSON.parse(v) : void 0;
+    return v !== '' && v !== undefined ? JSON.parse(v) : void 0;
   }
 
   toStateValue(v) {
@@ -26,7 +28,7 @@ export default class ObjectField extends BaseTextareaField {
       return v;
     }
 
-    return v === null ? "" : JSON.stringify(v || {}, null, 2);
+    return v === null ? '' : JSON.stringify(v || {}, null, 2);
   }
 
   validate(v, spec) {
@@ -38,11 +40,12 @@ export default class ObjectField extends BaseTextareaField {
     try {
       const o = v && JSON.parse(v);
       if (o && !_.isPlainObject(o)) {
-        return "value is not an object";
+        return 'value is not an object';
       }
 
       return false;
-    } catch (e) {
+    }
+    catch (e) {
       return e.message;
     }
   }


### PR DESCRIPTION
This is an *untested* fix for the charter bug. I cannot reproduce it myself but from the debug output from the Charter guys on the slack channel, I believe this should fix their issue. It appears when JSON.parse is called on a non json object.