### PR TITLE
Revert incorrect  "fix for charter bug"

### DIFF
--- a/modules/st2-auto-form/fields/object.js
+++ b/modules/st2-auto-form/fields/object.js
@@ -8,16 +8,11 @@ import _ from 'lodash';
 import { BaseTextareaField, isJinja } from './base';
 
 export default class ObjectField extends BaseTextareaField {
-  static icon = 'braces';
+  static icon = 'braces'
 
   fromStateValue(v) {
     if (isJinja(v)) {
       return v;
-    }
-
-    // check if object is valid
-    if (!_.isPlainObject(v)) {
-      return 0;
     }
 
     return v !== '' && v !== undefined ? JSON.parse(v) : void 0;
@@ -45,7 +40,7 @@ export default class ObjectField extends BaseTextareaField {
 
       return false;
     }
-    catch (e) {
+    catch(e) {
       return e.message;
     }
   }


### PR DESCRIPTION
Reverts extremenetworks/st2flow#365 which didn't fix the issue, but actually introduced a new regression when any input value was actually cast to `0`.

![](https://i.imgur.com/5nF3nEV.png)

Payload sent to StackStorm API looks the following: 
```
"parameters":{"trace_id":"2","component":"1","my_automation_object":0}
```

cc @emmetdel 