### PR TITLE
#374 - Change license for OpenSource

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -144,4 +144,4 @@ rules:
 
   notice/notice:
     - error
-    - mustMatch: "(// Copyright \\d{4} [a-zA-Z0-9,\\.\\s]+\\n)+//\\n// Unauthorized copying of this file, via any medium is strictly\\n// prohibited. Proprietary and confidential. See the LICENSE file\\n// included with this work for details\\.\\n"
+    - mustMatch: "(// Copyright \\d{4} [a-zA-Z0-9,\\.\\s]+\\n)+//\\n// Licensed under the Apache License, Version 2\\.0 \\(the \"License\"\\);\\n// you may not use this file except in compliance with the License\\.\\n// You may obtain a copy of the License at\\n//\\n//\\s+http://www\\.apache\\.org/licenses/LICENSE-2\\.0\\n//\\n// Unless required by applicable law or agreed to in writing, software\\n// distributed under the License is distributed on an \"AS IS\" BASIS,\\n// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\\n// See the License for the specific language governing permissions and\\n// limitations under the License\\.\\n"

--- a/LICENSE
+++ b/LICENSE
@@ -1,123 +1,202 @@
-Extreme Workflow Composer EULA
------------------------------------------
 
-This document is an agreement (“Agreement”) between You, the end user, and Extreme Networks, Inc., on behalf of itself and its Affiliates (“Extreme”) that sets forth your rights and obligations with respect to the “Licensed Materials”. BY INSTALLING SOFTWARE AND/OR THE LICENSE KEY FOR THE SOFTWARE (“License Key”) (collectively, “Licensed Software”), IF APPLICABLE, COPYING, OR OTHERWISE USING THE LICENSED SOFTWARE AND/OR ANY OF THE LICENSED MATERIALS UNDER THIS AGREEMENT, YOU ARE AGREEING TO BE BOUND BY THE TERMS OF THIS AGREEMENT, WHICH INCLUDES THE LICENSE(S) AND THE LIMITATION(S) OF WARRANTY AND DISCLAIMER(S)/LIMITATION(S) OF LIABILITY. IF YOU DO NOT AGREE TO THE TERMS OF THIS AGREEMENT, RETURN THE LICENSE KEY (IF APPLICABLE) TO EXTREME OR YOUR DEALER, IF ANY, OR DO NOT USE THE LICENSED SOFTWARE AND/OR LICENSED MATERIALS AND CONTACT EXTREME OR YOUR DEALER WITHIN TEN (10) DAYS FOLLOWING THE DATE OF RECEIPT TO ARRANGE FOR A REFUND. IF YOU HAVE ANY QUESTIONS ABOUT THIS AGREEMENT, CONTACT EXTREME, Attn: LegalTeam@extremenetworks.com.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-1. DEFINITIONS. “Affiliates” means any person, partnership, corporation, limited liability company, or other form of enterprise that directly or indirectly through one or more intermediaries, controls, or is controlled by, or is under common control with the party specified. “Server Application” means the software application associated to software authorized for installation (per License Key, if applicable) on one or more of Your servers as further defined in the Ordering Documentation. “Client Application” shall refer to the application to access the Server Application. “Network Device” for purposes of this Agreement shall mean a physical computer device, appliance, appliance component, controller, wireless access point, or virtual appliance as further described within the applicable product documentation, which includes the Order Documentation. “Licensed Materials” means the Licensed Software (including the Server Application and Client Application), Network Device (if applicable), Firmware, media embodying software, and the accompanying documentation. “Concurrent User” shall refer to any of Your individual employees who You provide access to the Server Application at any one time. “Firmware” refers to any software program or code embedded in chips or other media. “Standalone” software is software licensed for use independent of any hardware purchase as identified in the Ordering Documentation. “Licensed Software” collectively refers to the software, including Standalone software, Firmware, Server Application, Client Application or other application licensed with conditional use parameters as defined in the Ordering Documentation. “Ordering Documentation” shall mean the applicable price quotation, corresponding purchase order, relevant invoice, order acknowledgement, and accompanying documentation or specifications for the products and services purchased, acquired or licensed hereunder from Extreme either directly or indirectly.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-2. TERM. This Agreement is effective from the date on which You accept the terms and conditions of this Agreement via click-through, commence using the products and services or upon delivery of the License Key if applicable, and shall be effective until terminated. In the case of Licensed Materials offered on a subscription basis, the term of “licensed use” shall be as defined within Your Ordering Documentation.
+   1. Definitions.
 
-3. GRANT OF LICENSE. Extreme will grant You a non-transferable, non-sublicensable, non-exclusive license to use the Licensed Materials and the accompanying documentation for Your own business purposes subject to the terms and conditions of this Agreement, applicable licensing restrictions, and any term, user server networking device, field of use, or other restrictions as set forth in Your Ordering Documentation. If the Licensed Materials are being licensed on a subscription and/or capacity basis, the applicable term and/or capacity limit of the license shall be specified in Your Ordering Documentation. You may install and use the Licensed Materials as permitted by the license type purchased as described below in License Types. The license type purchased is specified on the invoice issued to You by Extreme or Your dealer, if any. YOU MAY NOT USE, COPY, OR MODIFY THE LICENSED MATERIALS, IN WHOLEOR IN PART, EXCEPT AS EXPRESSLY PROVIDED IN THIS AGREEMENT.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-4. LICENSE TYPES.
-* Single User, Single Network Device. Under the terms of this license type, the license granted to You by Extreme authorizes You to use the Licensed Materials as bundled with a single Network Device as identified by a unique serial number for the applicable Term, if and as specified in Your Ordering Documentation, or any replacement for that network device for that same Term, for internal use only. A separate license, under a separate License Agreement, is required for any other network device on which You or another individual, employee or other third party intend to use the Licensed Materials. A separate license under a separate License Agreement is also required if You wish to use a Client license (as described below).
-* Single User, Multiple Network Device. Under the terms of this license type, the license granted to You by Extreme authorizes You to use the Licensed Materials with a defined amount of Network Devices as defined in the Ordering Documentation.
-* Client. Under the terms of the Client license, the license granted to You by Extreme will authorize You to install the License Key for the Licensed Materials on your server and allow the specific number of Concurrent Users as ordered by you and is set forth in Your Ordering Documentation. A separate license is required for each additional Concurrent User.
-* Standalone. Software or other Licensed Materials licensed to You for use independent of any Network Device.
-* Subscription. Licensed Materials, and inclusive Software, Network Device or related appliance updates and maintenance services, licensed to You for use during a subscription period as defined in Your applicable Ordering Documentation.
-* Capacity. Under the terms of this license, the license granted to You by Extreme authorizes You to use the Licensed Materials up to the amount of capacity or usage as defined in the Ordering Documentation.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-5. AUDIT RIGHTS. You agree that Extreme may audit Your use of the Licensed Materials for compliance with these terms and Your License Type at any time, upon reasonable notice. In the event that such audit reveals any use of the Licensed Materials by You other than in full compliance with the license granted and the terms of this Agreement, Extreme reserves the right to charge You for all reasonable expenses related to such audit in addition to any other liabilities and overages applicable as a result of such non-compliance, including but not limited to additional fees for Concurrent Users, excess capacity or usage over and above those specifically granted to You. From time to time, the Licensed Materials may upload information about the Licensed Materials and the associated usage to Extreme. This is to verify the Licensed Materials are being used in accordance with a valid license and/or entitlement. By using the Licensed Materials, you
-consent to the transmission of this information.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-6. RESTRICTION AGAINST COPYING OR MODIFYING LICENSED MATERIALS. Except as expressly permitted in this Agreement, You may not copy or otherwise reproduce the Licensed Materials. In no event does the limited copying or reproduction permitted under this Agreement include the right to decompile,
-disassemble, electronically transfer, or reverse engineer the Licensed Materials, including the Licensed Software, or to translate the
-Licensed Materials into another computer language. The media embodying the Licensed Materials may be copied by You, in whole or
-in part, into printed or machine readable form, in sufficient numbers only for backup or archival purposes, or to replace a worn or defective
-copy. However, You agree not to have more than two (2) copies of the Licensed Software in whole or in part, including the original media, in
-your possession for said purposes without Extreme’ prior written consent, and in no event shall You operate more copies of the Licensed
-Software than the specific licenses granted to You. You may not copy or reproduce the documentation. You agree to maintain appropriate
-records of the location of the original media and all copies of the Licensed Software, in whole or in part, made by You. Any portion of
-the Licensed Software included in any such modular work shall be used only on a single computer for internal purposes and shall remain
-subject to all the terms and conditions of this Agreement. You agree to include any copyright or other proprietary notice set forth on the
-label of the media embodying the Licensed Software on any copy of the Licensed Software in any form, in whole or in part, or on any
-modification of the Licensed Software or any such modular work containing the Licensed Software or any part thereof.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-7. TITLE AND PROPRIETARY RIGHTS
-(a) The Licensed Materials are copyrighted works and are the sole and exclusive property of Extreme, any company or a division thereof
-which Extreme controls or is controlled by, or which may result from the merger or consolidation with Extreme (its “Affiliates”), and/or
-their suppliers. This Agreement conveys a limited right to operate the Licensed Materials and shall not be construed to convey title to the
-Licensed Materials to You. There are no implied rights. You shall not sell, lease, transfer, sublicense, dispose of, or otherwise make available
-the Licensed Materials or any portion thereof, to any other party.
-(b) You further acknowledge that in the event of a breach of this Agreement, Extreme shall suffer severe and irreparable damages for
-which monetary compensation alone will be inadequate. You therefore agree that in the event of a breach of this Agreement, Extreme
-shall be entitled to monetary damages and its reasonable attorney’s fees and costs in enforcing this Agreement, as well as injunctive relief
-to restrain such breach, in addition to any other remedies available to Extreme.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-8. PROTECTION AND SECURITY. In the performance of this
-Agreement or in contemplation thereof, You and your employees and agents may have access to private or confidential information owned
-or controlled by Extreme relating to the Licensed Materials supplied hereunder including, but not limited to, product specifications and
-schematics, and such information may contain proprietary details and disclosures. All information and data so acquired by You or your
-employees or agents under this Agreement or in contemplation hereof shall be and shall remain Extreme’ exclusive property, and You shall
-use all commercially reasonable efforts to keep, and have your employees and agents keep, any and all such information and data
-confidential, and shall not copy, publish, or disclose it to others, without Extreme’ prior written approval, and shall return such
-information and data to Extreme at its request. Nothing herein shall limit your use or dissemination of information not actually derived Extreme or of information which has been or subsequently is made public by Extreme, or a third party having authority to do so. You agree not to deliver or otherwise make available the Licensed Materials or any part thereof, including without limitation the object or source code (if provided) of the Licensed Software, to any party other than Extreme or its employees, except for purposes specifically related to your use of the Licensed Materials on a single computer as expressly provided in this Agreement, without the prior written consent of Extreme. You acknowledge that the Licensed Materials
-contain valuable confidential information and trade secrets, and that unauthorized use, copying and/or disclosure thereof are harmful to
-Extreme or its Affiliates and/or its/their software suppliers.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-9. MAINTENANCE AND UPDATES. Except as otherwise defined below, updates and certain maintenance and support services, if any, shall be provided to You pursuant to the terms of an Extreme Service and Maintenance Agreement, if Extreme and You enter into such an agreement. Except as specifically set forth in such agreement, Extreme shall not be under any obligation to provide updates, modifications, or enhancements, or maintenance and support services for the Licensed Materials to You. If you have purchased Licensed Materials on a subscription basis then the applicable service terms for
-Your Licensed Materials are as provided in Your Ordering Documentation. Extreme will perform the maintenance and updates in a timely and professional manner, during the Term of Your subscription, using qualified and experienced personnel. You will cooperate in good faith with Extreme in the performance of the support services including, but not limited to, providing Extreme with:
-(a) access to the Extreme Licensed Materials (and related systems); and
-(b) reasonably requested assistance and information. Further information about the applicable maintenance and updates terms can
-be found on Extreme’s website at http://www.extremenetworks.com/support/end-of-sale-and-end-ofsupport-products.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-10. DEFAULT AND TERMINATION. In the event that You shall fail to keep, observe, or perform any obligation under this Agreement,
-including a failure to pay any sums due to Extreme, or in the event that you become insolvent or seek protection, voluntarily or involuntarily,
-under any bankruptcy law, Extreme may, in addition to any other remedies it may have under law, terminate the License and any other
-agreements between Extreme and You.
-(a) Immediately after any termination of the Agreement, Your licensed subscription term, or if You have for any reason discontinued
-use of Licensed Materials, You shall return to Extreme the original and any copies of the Licensed Materials and remove the Licensed
-Materials, including an Licensed Software, from any modular works made pursuant to Section 3, and certify in writing that through your
-best efforts and to the best of your knowledge the original and all copies of the terminated or discontinued Licensed Materials have been
-returned to Extreme.
-(b) Sections 1, 7, 8, 10, 11, 12, 13, 14 and 15 shall survive termination of this Agreement for any reason.
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-11. EXPORT REQUIREMENTS. You are advised that the Licensed Materials, including the Licensed Software is of United States origin
-and subject to United States Export Administration Regulations; diversion contrary to United States law and regulation is prohibited.
-You agree not to directly or indirectly export, import or transmit the Licensed Materials, including the Licensed Software to any country,
-end user or for any Use that is prohibited by applicable United States regulation or statute (including but not limited to those countries
-embargoed from time to time by the United States government); or contrary to the laws or regulations of any other governmental entity
-that has jurisdiction over such export, import, transmission or Use.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-12. UNITED STATES GOVERNMENT RESTRICTED RIGHTS. The Licensed Materials (i) were developed solely at private expense;
-(ii) contain “restricted computer software” submitted with restricted rights in accordance with section 52.227-19 (a) through (d) of the
-Commercial Computer Software-Restricted Rights Clause and its successors, and (iii) in all respects is proprietary data belonging to
-Extreme and/or its suppliers. For Department of Defense units, the Licensed Materials are considered commercial computer software in
-accordance with DFARS section 227.7202-3 and its successors, and use, duplication, or disclosure by the U.S. Government is subject to
-restrictions set forth herein.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-13. LIMITED WARRANTY AND LIMITATION OF LIABILITY. Extreme warrants to You that (a) the initially-shipped version of the
-Licensed Materials will materially conform to the Documentation; and (b) the media on which the Licensed Software is recorded will be free
-from material defects for a period of ninety (90) days from the date of delivery to You or such other minimum period required under
-applicable law. Extreme does not warrant that Your use of the Licensed Materials will be error-free or uninterrupted.
-NEITHER EXTREME NOR ITS AFFILIATES MAKE ANY OTHER WARRANTY OR REPRESENTATION, EXPRESS OR IMPLIED, WITH RESPECT TO THE LICENSED MATERIALS, WHICH ARE
-LICENSED "AS IS". THE LIMITED WARRANTY AND REMEDY PROVIDED ABOVE ARE EXCLUSIVE AND IN LIEU OF ALL OTHER WARRANTIES, INCLUDING IMPLIED WARRANTIES
-OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, WHICH ARE EXPRESSLY DISCLAIMED, AND STATEMENTS OR REPRESENTATIONS MADE BY ANY
-OTHER PERSON OR FIRM ARE VOID. IN NO EVENT WILL EXTREME OR ANY OTHER PARTY WHO HAS BEEN INVOLVED IN THE CREATION, PRODUCTION OR DELIVERY
-OF THE LICENSED MATERIALS BE LIABLE FOR SPECIAL, DIRECT, INDIRECT, RELIANCE, INCIDENTAL OR CONSEQUENTIAL DAMAGES, INCLUDING LOSS OF DATA OR PROFITS OR FOR INABILITY TO USE THE LICENSED MATERIALS, TO ANY PARTY EVEN IF EXTREME OR SUCH OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. IN NO EVENT SHALL EXTREME OR SUCH OTHER PARTY'S LIABILITY FOR ANY DAMAGES OR LOSS TO YOU OR ANY OTHER PARTY EXCEED THE LICENSE FEE YOU PAID FOR THE LICENSED MATERIALS.
-Some states do not allow limitations on how long an implied warranty lasts and some states do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation and exclusion may not apply to You. This limited warranty gives You specific legal rights, and You may also have other rights which vary from state to state.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-14. JURISDICTION. The rights and obligations of the parties to this Agreement shall be governed and construed in accordance with the laws and in the State and Federal courts of the State of California, without regard to its rules with respect to choice of law. You waive any objections to the personal jurisdiction and venue of such courts. None of the 1980 United Nations Convention on the Limitation Period in the International Sale of Goods, and the Uniform Computer Information Transactions Act shall apply to this Agreement.
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-15. FREE AND OPEN SOURCE SOFTWARE. Portions of the Software (Open Source Software) provided to you may be subject to alicense that permits you to modify these portions and redistribute the modifications (an Open Source License). Your use, modification and redistribution of the Open Source Software are governed by the terms and conditions of the applicable Open Source License. More details regarding the Open Source Software and the applicable Open Source Licenses are available at www.extremenetworks.com/services/SoftwareLicensing.aspx. Some of the Open Source software may be subject to the GNU General Public License v.x (GPL) or the Lesser General Public Library (LGPL), copies of which are provided with the
-Licensed Materials and are further available for review at www.extremenetworks.com/services/SoftwareLicensing.aspx, or upon request as directed herein. In accordance with the terms of the GPL and LGPL, you may request a copy of the relevant source code. See the Software Licensing web site for additional details. This offer is valid for up to three years from the date of original download of the software.
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-16. GENERAL.
-(a) This Agreement is the entire agreement between Extreme and You regarding the Licensed Materials, and all prior agreements, representations, statements, and undertakings, oral or written, are hereby expressly superseded and canceled.
-(b) This Agreement may not be changed or amended except in writing signed by both parties hereto.
-(c) You represent that You have full right and/or authorization to enter into this Agreement.
-(d) This Agreement shall not be assignable by You without the express written consent of Extreme. The rights of Extreme and Your
-obligations under this Agreement shall inure to the benefit of Extreme’ assignees, licensors, and licensees.
-(e) Section headings are for convenience only and shall not be considered in the interpretation of this Agreement.
-(f) The provisions of the Agreement are severable and if any one or more of the provisions hereof are judicially determined to be illegal or
-otherwise unenforceable, in whole or in part, the remaining provisions of this Agreement shall nevertheless be binding on and enforceable by
-and between the parties hereto.
-(g) Extreme’s waiver of any right shall not constitute waiver of that right in future. This Agreement constitutes the entire understanding
-between the parties with respect to the subject matter hereof, and all prior agreements, representations, statements and undertakings, oral or
-written, are hereby expressly superseded and canceled. No purchase order shall supersede this Agreement.
-(h) Should You have any questions regarding this Agreement, You may contact Extreme at the address set forth below. Any notice or
-other communication to be sent to Extreme must be mailed by certified mail to the following address:
-Extreme Networks, Inc.
-145 Rio Robles
-San Jose, CA 95134 United States
-ATTN: Legal Department
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ gulp lint
 
 Copyright 2015-2020 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly prohibited. Proprietary and confidential. See the [LICENSE](LICENSE) file included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License in the [LICENSE](LICENSE) file, or at:
+
+[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 By contributing you agree that these contributions are your own (or approved by your employer) and you grant a full, complete, irrevocable copyright license to all users and developers of the project, present and future, pursuant to the license of the project.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 module.exports = function (api) {
   api.cache(true);

--- a/config.js
+++ b/config.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 'use strict';
 

--- a/debian/control
+++ b/debian/control
@@ -1,10 +1,10 @@
 Source: st2flow
 Section: unknown
 Priority: optional
-Maintainer: Extreme Networks <support@extremenetworks.com>
+Maintainer: StackStorm Authors
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://www.extremenetworks.com/product/workflow-composer/
+Homepage: https://github.com/StackStorm/st2flow
 
 Package: st2flow
 Architecture: any

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,127 +3,205 @@ Upstream-Name: st2flow
 Source: https://www.extremenetworks.com/product/workflow-composer/
 
 Files: *
-Copyright: 2016-2019 Extreme Networks <support@extremenetworks.com>
-License: Extreme_Workflow_Composer_EULA
-Extreme Workflow Composer EULA
------------------------------------------
- This document is an agreement (“Agreement”) between You, the end user, and Extreme Networks, Inc., on behalf of itself and its Affiliates (“Extreme”) that sets forth your rights and obligations with respect to the “Licensed Materials”. BY INSTALLING SOFTWARE AND/OR THE LICENSE KEY FOR THE SOFTWARE (“License Key”) (collectively, “Licensed Software”), IF APPLICABLE, COPYING, OR OTHERWISE USING THE LICENSED SOFTWARE AND/OR ANY OF THE LICENSED MATERIALS UNDER THIS AGREEMENT, YOU ARE AGREEING TO BE BOUND BY THE TERMS OF THIS AGREEMENT, WHICH INCLUDES THE LICENSE(S) AND THE LIMITATION(S) OF WARRANTY AND DISCLAIMER(S)/LIMITATION(S) OF LIABILITY. IF YOU DO NOT AGREE TO THE TERMS OF THIS AGREEMENT, RETURN THE LICENSE KEY (IF APPLICABLE) TO EXTREME OR YOUR DEALER, IF ANY, OR DO NOT USE THE LICENSED SOFTWARE AND/OR LICENSED MATERIALS AND CONTACT EXTREME OR YOUR DEALER WITHIN TEN (10) DAYS FOLLOWING THE DATE OF RECEIPT TO ARRANGE FOR A REFUND. IF YOU HAVE ANY QUESTIONS ABOUT THIS AGREEMENT, CONTACT EXTREME, Attn: LegalTeam@extremenetworks.com.
- .
- 1. DEFINITIONS. “Affiliates” means any person, partnership, corporation, limited liability company, or other form of enterprise that directly or indirectly through one or more intermediaries, controls, or is controlled by, or is under common control with the party specified. “Server Application” means the software application associated to software authorized for installation (per License Key, if applicable) on one or more of Your servers as further defined in the Ordering Documentation. “Client Application” shall refer to the application to access the Server Application. “Network Device” for purposes of this Agreement shall mean a physical computer device, appliance, appliance component, controller, wireless access point, or virtual appliance as further described within the applicable product documentation, which includes the Order Documentation. “Licensed Materials” means the Licensed Software (including the Server Application and Client Application), Network Device (if applicable), Firmware, media embodying software, and the accompanying documentation. “Concurrent User” shall refer to any of Your individual employees who You provide access to the Server Application at any one time. “Firmware” refers to any software program or code embedded in chips or other media. “Standalone” software is software licensed for use independent of any hardware purchase as identified in the Ordering Documentation. “Licensed Software” collectively refers to the software, including Standalone software, Firmware, Server Application, Client Application or other application licensed with conditional use parameters as defined in the Ordering Documentation. “Ordering Documentation” shall mean the applicable price quotation, corresponding purchase order, relevant invoice, order acknowledgement, and accompanying documentation or specifications for the products and services purchased, acquired or licensed hereunder from Extreme either directly or indirectly.
- .
- 2. TERM. This Agreement is effective from the date on which You accept the terms and conditions of this Agreement via click-through, commence using the products and services or upon delivery of the License Key if applicable, and shall be effective until terminated. In the case of Licensed Materials offered on a subscription basis, the term of “licensed use” shall be as defined within Your Ordering Documentation.
- .
- 3. GRANT OF LICENSE. Extreme will grant You a non-transferable, non-sublicensable, non-exclusive license to use the Licensed Materials and the accompanying documentation for Your own business purposes subject to the terms and conditions of this Agreement, applicable licensing restrictions, and any term, user server networking device, field of use, or other restrictions as set forth in Your Ordering Documentation. If the Licensed Materials are being licensed on a subscription and/or capacity basis, the applicable term and/or capacity limit of the license shall be specified in Your Ordering Documentation. You may install and use the Licensed Materials as permitted by the license type purchased as described below in License Types. The license type purchased is specified on the invoice issued to You by Extreme or Your dealer, if any. YOU MAY NOT USE, COPY, OR MODIFY THE LICENSED MATERIALS, IN WHOLEOR IN PART, EXCEPT AS EXPRESSLY PROVIDED IN THIS AGREEMENT.
- .
- 4. LICENSE TYPES.
- * Single User, Single Network Device. Under the terms of this license type, the license granted to You by Extreme authorizes You to use the Licensed Materials as bundled with a single Network Device as identified by a unique serial number for the applicable Term, if and as specified in Your Ordering Documentation, or any replacement for that network device for that same Term, for internal use only. A separate license, under a separate License Agreement, is required for any other network device on which You or another individual, employee or other third party intend to use the Licensed Materials. A separate license under a separate License Agreement is also required if You wish to use a Client license (as described below).
- * Single User, Multiple Network Device. Under the terms of this license type, the license granted to You by Extreme authorizes You to use the Licensed Materials with a defined amount of Network Devices as defined in the Ordering Documentation.
- * Client. Under the terms of the Client license, the license granted to You by Extreme will authorize You to install the License Key for the Licensed Materials on your server and allow the specific number of Concurrent Users as ordered by you and is set forth in Your Ordering Documentation. A separate license is required for each additional Concurrent User.
- * Standalone. Software or other Licensed Materials licensed to You for use independent of any Network Device.
- * Subscription. Licensed Materials, and inclusive Software, Network Device or related appliance updates and maintenance services, licensed to You for use during a subscription period as defined in Your applicable Ordering Documentation.
- * Capacity. Under the terms of this license, the license granted to You by Extreme authorizes You to use the Licensed Materials up to the amount of capacity or usage as defined in the Ordering Documentation.
- .
- 5. AUDIT RIGHTS. You agree that Extreme may audit Your use of the Licensed Materials for compliance with these terms and Your License Type at any time, upon reasonable notice. In the event that such audit reveals any use of the Licensed Materials by You other than in full compliance with the license granted and the terms of this Agreement, Extreme reserves the right to charge You for all reasonable expenses related to such audit in addition to any other liabilities and overages applicable as a result of such non-compliance, including but not limited to additional fees for Concurrent Users, excess capacity or usage over and above those specifically granted to You. From time to time, the Licensed Materials may upload information about the Licensed Materials and the associated usage to Extreme. This is to verify the Licensed Materials are being used in accordance with a valid license and/or entitlement. By using the Licensed Materials, you
- consent to the transmission of this information.
- .
- 6. RESTRICTION AGAINST COPYING OR MODIFYING LICENSED MATERIALS. Except as expressly permitted in this Agreement, You may not copy or otherwise reproduce the Licensed Materials. In no event does the limited copying or reproduction permitted under this Agreement include the right to decompile,
- disassemble, electronically transfer, or reverse engineer the Licensed Materials, including the Licensed Software, or to translate the
- Licensed Materials into another computer language. The media embodying the Licensed Materials may be copied by You, in whole or
- in part, into printed or machine readable form, in sufficient numbers only for backup or archival purposes, or to replace a worn or defective
- copy. However, You agree not to have more than two (2) copies of the Licensed Software in whole or in part, including the original media, in
- your possession for said purposes without Extreme’ prior written consent, and in no event shall You operate more copies of the Licensed
- Software than the specific licenses granted to You. You may not copy or reproduce the documentation. You agree to maintain appropriate
- records of the location of the original media and all copies of the Licensed Software, in whole or in part, made by You. Any portion of
- the Licensed Software included in any such modular work shall be used only on a single computer for internal purposes and shall remain
- subject to all the terms and conditions of this Agreement. You agree to include any copyright or other proprietary notice set forth on the
- label of the media embodying the Licensed Software on any copy of the Licensed Software in any form, in whole or in part, or on any
- modification of the Licensed Software or any such modular work containing the Licensed Software or any part thereof.
- .
- 7. TITLE AND PROPRIETARY RIGHTS
- (a) The Licensed Materials are copyrighted works and are the sole and exclusive property of Extreme, any company or a division thereof
- which Extreme controls or is controlled by, or which may result from the merger or consolidation with Extreme (its “Affiliates”), and/or
- their suppliers. This Agreement conveys a limited right to operate the Licensed Materials and shall not be construed to convey title to the
- Licensed Materials to You. There are no implied rights. You shall not sell, lease, transfer, sublicense, dispose of, or otherwise make available
- the Licensed Materials or any portion thereof, to any other party.
- (b) You further acknowledge that in the event of a breach of this Agreement, Extreme shall suffer severe and irreparable damages for
- which monetary compensation alone will be inadequate. You therefore agree that in the event of a breach of this Agreement, Extreme
- shall be entitled to monetary damages and its reasonable attorney’s fees and costs in enforcing this Agreement, as well as injunctive relief
- to restrain such breach, in addition to any other remedies available to Extreme.
- .
- 8. PROTECTION AND SECURITY. In the performance of this
- Agreement or in contemplation thereof, You and your employees and agents may have access to private or confidential information owned
- or controlled by Extreme relating to the Licensed Materials supplied hereunder including, but not limited to, product specifications and
- schematics, and such information may contain proprietary details and disclosures. All information and data so acquired by You or your
- employees or agents under this Agreement or in contemplation hereof shall be and shall remain Extreme’ exclusive property, and You shall
- use all commercially reasonable efforts to keep, and have your employees and agents keep, any and all such information and data
- confidential, and shall not copy, publish, or disclose it to others, without Extreme’ prior written approval, and shall return such
- information and data to Extreme at its request. Nothing herein shall limit your use or dissemination of information not actually derived Extreme or of information which has been or subsequently is made public by Extreme, or a third party having authority to do so. You agree not to deliver or otherwise make available the Licensed Materials or any part thereof, including without limitation the object or source code (if provided) of the Licensed Software, to any party other than Extreme or its employees, except for purposes specifically related to your use of the Licensed Materials on a single computer as expressly provided in this Agreement, without the prior written consent of Extreme. You acknowledge that the Licensed Materials
- contain valuable confidential information and trade secrets, and that unauthorized use, copying and/or disclosure thereof are harmful to
- Extreme or its Affiliates and/or its/their software suppliers.
- .
- 9. MAINTENANCE AND UPDATES. Except as otherwise defined below, updates and certain maintenance and support services, if any, shall be provided to You pursuant to the terms of an Extreme Service and Maintenance Agreement, if Extreme and You enter into such an agreement. Except as specifically set forth in such agreement, Extreme shall not be under any obligation to provide updates, modifications, or enhancements, or maintenance and support services for the Licensed Materials to You. If you have purchased Licensed Materials on a subscription basis then the applicable service terms for
- Your Licensed Materials are as provided in Your Ordering Documentation. Extreme will perform the maintenance and updates in a timely and professional manner, during the Term of Your subscription, using qualified and experienced personnel. You will cooperate in good faith with Extreme in the performance of the support services including, but not limited to, providing Extreme with:
- (a) access to the Extreme Licensed Materials (and related systems); and
- (b) reasonably requested assistance and information. Further information about the applicable maintenance and updates terms can
- be found on Extreme’s website at http://www.extremenetworks.com/support/end-of-sale-and-end-ofsupport-products.
- .
- 10. DEFAULT AND TERMINATION. In the event that You shall fail to keep, observe, or perform any obligation under this Agreement,
- including a failure to pay any sums due to Extreme, or in the event that you become insolvent or seek protection, voluntarily or involuntarily,
- under any bankruptcy law, Extreme may, in addition to any other remedies it may have under law, terminate the License and any other
- agreements between Extreme and You.
- (a) Immediately after any termination of the Agreement, Your licensed subscription term, or if You have for any reason discontinued
- use of Licensed Materials, You shall return to Extreme the original and any copies of the Licensed Materials and remove the Licensed
- Materials, including an Licensed Software, from any modular works made pursuant to Section 3, and certify in writing that through your
- best efforts and to the best of your knowledge the original and all copies of the terminated or discontinued Licensed Materials have been
- returned to Extreme.
- (b) Sections 1, 7, 8, 10, 11, 12, 13, 14 and 15 shall survive termination of this Agreement for any reason.
- .
- 11. EXPORT REQUIREMENTS. You are advised that the Licensed Materials, including the Licensed Software is of United States origin
- and subject to United States Export Administration Regulations; diversion contrary to United States law and regulation is prohibited.
- You agree not to directly or indirectly export, import or transmit the Licensed Materials, including the Licensed Software to any country,
- end user or for any Use that is prohibited by applicable United States regulation or statute (including but not limited to those countries
- embargoed from time to time by the United States government); or contrary to the laws or regulations of any other governmental entity
- that has jurisdiction over such export, import, transmission or Use.
- .
- 12. UNITED STATES GOVERNMENT RESTRICTED RIGHTS. The Licensed Materials (i) were developed solely at private expense;
- (ii) contain “restricted computer software” submitted with restricted rights in accordance with section 52.227-19 (a) through (d) of the
- Commercial Computer Software-Restricted Rights Clause and its successors, and (iii) in all respects is proprietary data belonging to
- Extreme and/or its suppliers. For Department of Defense units, the Licensed Materials are considered commercial computer software in
- accordance with DFARS section 227.7202-3 and its successors, and use, duplication, or disclosure by the U.S. Government is subject to
- restrictions set forth herein.
- .
- 13. LIMITED WARRANTY AND LIMITATION OF LIABILITY. Extreme warrants to You that (a) the initially-shipped version of the
- Licensed Materials will materially conform to the Documentation; and (b) the media on which the Licensed Software is recorded will be free
- from material defects for a period of ninety (90) days from the date of delivery to You or such other minimum period required under
- applicable law. Extreme does not warrant that Your use of the Licensed Materials will be error-free or uninterrupted.
- NEITHER EXTREME NOR ITS AFFILIATES MAKE ANY OTHER WARRANTY OR REPRESENTATION, EXPRESS OR IMPLIED, WITH RESPECT TO THE LICENSED MATERIALS, WHICH ARE
- LICENSED "AS IS". THE LIMITED WARRANTY AND REMEDY PROVIDED ABOVE ARE EXCLUSIVE AND IN LIEU OF ALL OTHER WARRANTIES, INCLUDING IMPLIED WARRANTIES
- OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, WHICH ARE EXPRESSLY DISCLAIMED, AND STATEMENTS OR REPRESENTATIONS MADE BY ANY
- OTHER PERSON OR FIRM ARE VOID. IN NO EVENT WILL EXTREME OR ANY OTHER PARTY WHO HAS BEEN INVOLVED IN THE CREATION, PRODUCTION OR DELIVERY
- OF THE LICENSED MATERIALS BE LIABLE FOR SPECIAL, DIRECT, INDIRECT, RELIANCE, INCIDENTAL OR CONSEQUENTIAL DAMAGES, INCLUDING LOSS OF DATA OR PROFITS OR FOR INABILITY TO USE THE LICENSED MATERIALS, TO ANY PARTY EVEN IF EXTREME OR SUCH OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. IN NO EVENT SHALL EXTREME OR SUCH OTHER PARTY'S LIABILITY FOR ANY DAMAGES OR LOSS TO YOU OR ANY OTHER PARTY EXCEED THE LICENSE FEE YOU PAID FOR THE LICENSED MATERIALS.
- Some states do not allow limitations on how long an implied warranty lasts and some states do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation and exclusion may not apply to You. This limited warranty gives You specific legal rights, and You may also have other rights which vary from state to state.
- .
- 14. JURISDICTION. The rights and obligations of the parties to this Agreement shall be governed and construed in accordance with the laws and in the State and Federal courts of the State of California, without regard to its rules with respect to choice of law. You waive any objections to the personal jurisdiction and venue of such courts. None of the 1980 United Nations Convention on the Limitation Period in the International Sale of Goods, and the Uniform Computer Information Transactions Act shall apply to this Agreement.
- .
- 15. FREE AND OPEN SOURCE SOFTWARE. Portions of the Software (Open Source Software) provided to you may be subject to alicense that permits you to modify these portions and redistribute the modifications (an Open Source License). Your use, modification and redistribution of the Open Source Software are governed by the terms and conditions of the applicable Open Source License. More details regarding the Open Source Software and the applicable Open Source Licenses are available at www.extremenetworks.com/services/SoftwareLicensing.aspx. Some of the Open Source software may be subject to the GNU General Public License v.x (GPL) or the Lesser General Public Library (LGPL), copies of which are provided with the
- Licensed Materials and are further available for review at www.extremenetworks.com/services/SoftwareLicensing.aspx, or upon request as directed herein. In accordance with the terms of the GPL and LGPL, you may request a copy of the relevant source code. See the Software Licensing web site for additional details. This offer is valid for up to three years from the date of original download of the software.
- .
- 16. GENERAL.
- (a) This Agreement is the entire agreement between Extreme and You regarding the Licensed Materials, and all prior agreements, representations, statements, and undertakings, oral or written, are hereby expressly superseded and canceled.
- (b) This Agreement may not be changed or amended except in writing signed by both parties hereto.
- (c) You represent that You have full right and/or authorization to enter into this Agreement.
- (d) This Agreement shall not be assignable by You without the express written consent of Extreme. The rights of Extreme and Your
- obligations under this Agreement shall inure to the benefit of Extreme’ assignees, licensors, and licensees.
- (e) Section headings are for convenience only and shall not be considered in the interpretation of this Agreement.
- (f) The provisions of the Agreement are severable and if any one or more of the provisions hereof are judicially determined to be illegal or
- otherwise unenforceable, in whole or in part, the remaining provisions of this Agreement shall nevertheless be binding on and enforceable by
- and between the parties hereto.
- (g) Extreme’s waiver of any right shall not constitute waiver of that right in future. This Agreement constitutes the entire understanding
- between the parties with respect to the subject matter hereof, and all prior agreements, representations, statements and undertakings, oral or
- written, are hereby expressly superseded and canceled. No purchase order shall supersede this Agreement.
- (h) Should You have any questions regarding this Agreement, You may contact Extreme at the address set forth below. Any notice or
- other communication to be sent to Extreme must be mailed by certified mail to the following address:
- Extreme Networks, Inc.
- 145 Rio Robles
- San Jose, CA 95134 United States
- ATTN: Legal Department
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /* jshint node: true */
 'use strict';

--- a/main.js
+++ b/main.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
@@ -199,7 +207,7 @@ class Window extends Component<{
       ...runFormData,
     };
 
-    
+
     return api.request({
       method: 'post',
       path: '/executions',

--- a/modules/st2-api/api.js
+++ b/modules/st2-api/api.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import _ from 'lodash';
 import url from 'url';
@@ -99,7 +107,7 @@ export class API {
             message: res.data.faultstring || res.data,
           };
         }
-  
+
         this.token = res.data;
       }
       catch (err) {
@@ -171,7 +179,7 @@ export class API {
     if (this.token && this.token.token) {
       headers['x-auth-token'] = this.token.token;
     }
-    
+
     const config = {
       method,
       url: this.route(opts),
@@ -181,14 +189,14 @@ export class API {
       data,
       withCredentials: true,
     };
-  
+
     if (this.rejectUnauthorized === false) {
       process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
     }
     else {
       process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1';
     }
-  
+
     const response = await axios(config);
 
     const contentType = (response.headers || {})['content-type'] || [];

--- a/modules/st2-api/tests/test-api.js
+++ b/modules/st2-api/tests/test-api.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import { expect } from 'chai';
 

--- a/modules/st2-auto-form/auto-form.component.js
+++ b/modules/st2-auto-form/auto-form.component.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import _ from 'lodash';
 import React from 'react';

--- a/modules/st2-auto-form/fields/array.js
+++ b/modules/st2-auto-form/fields/array.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import _ from 'lodash';
 import validator from 'validator';

--- a/modules/st2-auto-form/fields/base.js
+++ b/modules/st2-auto-form/fields/base.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import _ from 'lodash';
 import React from 'react';

--- a/modules/st2-auto-form/fields/boolean.js
+++ b/modules/st2-auto-form/fields/boolean.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from 'react';
 

--- a/modules/st2-auto-form/fields/color-string.js
+++ b/modules/st2-auto-form/fields/color-string.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/modules/st2-auto-form/fields/enum.js
+++ b/modules/st2-auto-form/fields/enum.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import _ from 'lodash';
 import React from 'react';

--- a/modules/st2-auto-form/fields/index.js
+++ b/modules/st2-auto-form/fields/index.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import ArrayField from './array';
 import BooleanField from './boolean';

--- a/modules/st2-auto-form/fields/integer.js
+++ b/modules/st2-auto-form/fields/integer.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import validator from 'validator';
 

--- a/modules/st2-auto-form/fields/number.js
+++ b/modules/st2-auto-form/fields/number.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import validator from 'validator';
 

--- a/modules/st2-auto-form/fields/object.js
+++ b/modules/st2-auto-form/fields/object.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import _ from 'lodash';
 import { BaseTextareaField, isJinja } from './base';
@@ -18,7 +26,7 @@ export default class ObjectField extends BaseTextareaField {
     if (v !== '' && v !== undefined) {
       try {
         return JSON.parse(v);
-      } 
+      }
       catch (error) {
         console.error('Could not parse JSON - ', error);
         return void 0;

--- a/modules/st2-auto-form/fields/password.js
+++ b/modules/st2-auto-form/fields/password.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import { BaseTextField } from './base';
 

--- a/modules/st2-auto-form/fields/select.js
+++ b/modules/st2-auto-form/fields/select.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import _ from 'lodash';
 import React from 'react';

--- a/modules/st2-auto-form/fields/string.js
+++ b/modules/st2-auto-form/fields/string.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import { BaseTextareaField } from './base';
 

--- a/modules/st2-auto-form/modules/array.js
+++ b/modules/st2-auto-form/modules/array.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from 'react';
 import { PropTypes } from 'prop-types';

--- a/modules/st2-auto-form/modules/checkbox.js
+++ b/modules/st2-auto-form/modules/checkbox.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from 'react';
 import { PropTypes } from 'prop-types';

--- a/modules/st2-auto-form/modules/combobox.js
+++ b/modules/st2-auto-form/modules/combobox.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from 'react';
 import { PropTypes } from 'prop-types';
@@ -88,7 +96,7 @@ export default class ComboboxModule extends React.Component {
 
     if (value === null) {
       return;
-    } 
+    }
 
     this.setState({ value: null });
     this.props.onChange(value);

--- a/modules/st2-auto-form/modules/index.js
+++ b/modules/st2-auto-form/modules/index.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import ArrayModule from './array';
 import CheckboxModule from './checkbox';

--- a/modules/st2-auto-form/modules/input.js
+++ b/modules/st2-auto-form/modules/input.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from 'react';
 import { PropTypes } from 'prop-types';

--- a/modules/st2-auto-form/modules/link.js
+++ b/modules/st2-auto-form/modules/link.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from 'react';
 import { PropTypes } from 'prop-types';

--- a/modules/st2-auto-form/modules/object.js
+++ b/modules/st2-auto-form/modules/object.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from 'react';
 import { PropTypes } from 'prop-types';

--- a/modules/st2-auto-form/modules/select.js
+++ b/modules/st2-auto-form/modules/select.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from 'react';
 import { PropTypes } from 'prop-types';

--- a/modules/st2-auto-form/modules/text-field.js
+++ b/modules/st2-auto-form/modules/text-field.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from 'react';
 import { PropTypes } from 'prop-types';

--- a/modules/st2-auto-form/style.css
+++ b/modules/st2-auto-form/style.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2-auto-form/style.css
+++ b/modules/st2-auto-form/style.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 @import "@stackstorm/st2-style/colors.css";

--- a/modules/st2-auto-form/wrappers.js
+++ b/modules/st2-auto-form/wrappers.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from 'react';
 import { PropTypes } from 'prop-types';

--- a/modules/st2-forms/button.component.js
+++ b/modules/st2-forms/button.component.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import { uniqueId } from 'lodash';
 import React from 'react';
@@ -19,7 +27,7 @@ export class Toggle extends React.Component {
   }
 
   _id = uniqueId('st2toggle')
-  
+
   handleChange(value) {
     return this.props.onChange && this.props.onChange(value);
   }

--- a/modules/st2-forms/style.css
+++ b/modules/st2-forms/style.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2-forms/style.css
+++ b/modules/st2-forms/style.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 @import "@stackstorm/st2-style/colors.css";
@@ -212,7 +220,7 @@ included with this work for details.
 
     input[type=checkbox] {
       display: none;
-  
+
       /* add default box-sizing for this scope */
       &,
       &:after,
@@ -226,7 +234,7 @@ included with this work for details.
           background: none;
         }
       }
-      
+
       + label {
         outline: 0;
         display: block;
@@ -243,16 +251,16 @@ included with this work for details.
           width: 50%;
           height: 100%;
         }
-        
+
         &:after {
           left: 0;
         }
-        
+
         &:before {
           display: none;
         }
       }
-      
+
       &:checked + label:after {
         left: 50%;
       }
@@ -268,7 +276,7 @@ included with this work for details.
           transition: all .2s ease;
         }
       }
-      
+
       &:checked + label {
         background: var(--green-base);
       }

--- a/modules/st2-login/login.component.js
+++ b/modules/st2-login/login.component.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from 'react';
 import { PropTypes } from 'prop-types';
@@ -143,11 +151,11 @@ export default class Login extends React.Component {
 
     this.state = {
       error: null,
-      
+
       username: '',
       password: '',
       remember: true,
-  
+
       server,
       servers,
     };

--- a/modules/st2-login/style.css
+++ b/modules/st2-login/style.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2-login/style.css
+++ b/modules/st2-login/style.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 @import "@stackstorm/st2-style/colors.css";

--- a/modules/st2-login/tests/test-login.js
+++ b/modules/st2-login/tests/test-login.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import { expect } from 'chai';
 

--- a/modules/st2-router/history.js
+++ b/modules/st2-router/history.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import createHashHistory from 'history/createHashHistory';
 

--- a/modules/st2-router/index.js
+++ b/modules/st2-router/index.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 export { default as Router } from './router.component';
 export { default as Route } from './route.component';

--- a/modules/st2-router/link.component.js
+++ b/modules/st2-router/link.component.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from 'react';
 import { PropTypes } from 'prop-types';
@@ -66,7 +74,7 @@ export default class Link extends React.Component {
         : to;
 
     const href = `#${createPath(targetLocation)}`;
-    
+
     return (
       <a {...props} onClick={this.handleClick} href={href} ref={innerRef} />
     );

--- a/modules/st2-router/methods.js
+++ b/modules/st2-router/methods.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import store from '@stackstorm/module-store';
 

--- a/modules/st2-router/redirect.component.js
+++ b/modules/st2-router/redirect.component.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from 'react';
 import { PropTypes } from 'prop-types';

--- a/modules/st2-router/reducer.js
+++ b/modules/st2-router/reducer.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 export default function reducer(state = {}, action) {
   state = { ...state };

--- a/modules/st2-router/route.component.js
+++ b/modules/st2-router/route.component.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import React from 'react';
 import { PropTypes } from 'prop-types';

--- a/modules/st2-router/router.component.js
+++ b/modules/st2-router/router.component.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import fp from 'lodash/fp';
 import React from 'react';
@@ -67,7 +75,7 @@ export default class Router extends React.Component {
     if (!api.isConnected()) {
       return <Login onConnect={() => history.replace()} />;
     }
- 
+
     for (const { url, Component } of routes) {
       const regex = url instanceof RegExp ? regex : new RegExp(`^${url}`);
       const match = location.pathname.match(regex);

--- a/modules/st2-store/store.js
+++ b/modules/st2-store/store.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import { createStore, applyMiddleware, compose } from 'redux';
 import routerReducer from '@stackstorm/module-router/reducer';

--- a/modules/st2-style/colors.css
+++ b/modules/st2-style/colors.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2-style/colors.css
+++ b/modules/st2-style/colors.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 :root {

--- a/modules/st2-style/font/DroidSansMono.css
+++ b/modules/st2-style/font/DroidSansMono.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2-style/font/DroidSansMono.css
+++ b/modules/st2-style/font/DroidSansMono.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 @font-face {

--- a/modules/st2-style/font/Roboto.css
+++ b/modules/st2-style/font/Roboto.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2-style/font/Roboto.css
+++ b/modules/st2-style/font/Roboto.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 @font-face {

--- a/modules/st2-style/font/animation.css
+++ b/modules/st2-style/font/animation.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 /*

--- a/modules/st2-style/font/animation.css
+++ b/modules/st2-style/font/animation.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2-style/font/brocadeicons.css
+++ b/modules/st2-style/font/brocadeicons.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2-style/font/brocadeicons.css
+++ b/modules/st2-style/font/brocadeicons.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 @font-face {

--- a/modules/st2-style/font/st2.css
+++ b/modules/st2-style/font/st2.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2-style/font/st2.css
+++ b/modules/st2-style/font/st2.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 @font-face {

--- a/modules/st2-style/font/ststanley-codes.css
+++ b/modules/st2-style/font/ststanley-codes.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2-style/font/ststanley-codes.css
+++ b/modules/st2-style/font/ststanley-codes.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 

--- a/modules/st2-style/font/ststanley-embedded.css
+++ b/modules/st2-style/font/ststanley-embedded.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 @font-face {
@@ -29,34 +37,34 @@ included with this work for details.
   }
 }
 */
- 
+
  [class^="st2-icon__"]:before, [class*=" st2-icon__"]:before {
   font-family: "ststanley";
   font-style: normal;
   font-weight: normal;
   speak: none;
- 
+
   display: inline-block;
   text-decoration: inherit;
   width: 1em;
   margin-right: .2em;
   text-align: center;
   /* opacity: .8; */
- 
+
   /* For safety - reset parent styles, that can break glyph codes*/
   font-variant: normal;
   text-transform: none;
-     
+
   /* fix buttons height, for twitter bootstrap */
   line-height: 1em;
- 
+
   /* Animation center compensation - margins should be symmetric */
   /* remove if not needed */
   margin-left: .2em;
- 
+
   /* you can be more comfortable with increased icons size */
   /* font-size: 120%; */
- 
+
   /* Uncomment for 3D effect */
   /* text-shadow: 1px 1px 1px rgba(127, 127, 127, 0.3); */
 }

--- a/modules/st2-style/font/ststanley-ie7-codes.css
+++ b/modules/st2-style/font/ststanley-ie7-codes.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2-style/font/ststanley-ie7-codes.css
+++ b/modules/st2-style/font/ststanley-ie7-codes.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 

--- a/modules/st2-style/font/ststanley-ie7.css
+++ b/modules/st2-style/font/ststanley-ie7.css
@@ -1,23 +1,31 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 [class^="st2-icon__"], [class*=" st2-icon__"] {
   font-family: 'ststanley';
   font-style: normal;
   font-weight: normal;
- 
+
   /* fix buttons height */
   line-height: 1em;
- 
+
   /* you can be more comfortable with increased icons size */
   /* font-size: 120%; */
 }
- 
+
 .st2-icon__off { *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#xe800;&nbsp;'); }
 .st2-icon__edit { *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#xe801;&nbsp;'); }
 .st2-icon__cancel { *zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#xe802;&nbsp;'); }

--- a/modules/st2-style/font/ststanley-ie7.css
+++ b/modules/st2-style/font/ststanley-ie7.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2-style/font/ststanley.css
+++ b/modules/st2-style/font/ststanley.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2-style/font/ststanley.css
+++ b/modules/st2-style/font/ststanley.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 @font-face {
@@ -26,38 +34,38 @@ included with this work for details.
   }
 }
 */
- 
+
  [class^="st2-icon__"]:before, [class*=" st2-icon__"]:before {
   font-family: "ststanley";
   font-style: normal;
   font-weight: normal;
   speak: none;
- 
+
   display: inline-block;
   text-decoration: inherit;
   width: 1em;
   margin-right: .2em;
   text-align: center;
   /* opacity: .8; */
- 
+
   /* For safety - reset parent styles, that can break glyph codes*/
   font-variant: normal;
   text-transform: none;
-     
+
   /* fix buttons height, for twitter bootstrap */
   line-height: 1em;
- 
+
   /* Animation center compensation - margins should be symmetric */
   /* remove if not needed */
   margin-left: .2em;
- 
+
   /* you can be more comfortable with increased icons size */
   /* font-size: 120%; */
- 
+
   /* Uncomment for 3D effect */
   /* text-shadow: 1px 1px 1px rgba(127, 127, 127, 0.3); */
 }
- 
+
 .st2-icon__off:before { content: '\e800'; } /* '' */
 .st2-icon__edit:before { content: '\e801'; } /* '' */
 .st2-icon__cancel:before { content: '\e802'; } /* '' */

--- a/modules/st2-style/fonts.css
+++ b/modules/st2-style/fonts.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 /* @import "font/brocadeicons.css"; */

--- a/modules/st2-style/fonts.css
+++ b/modules/st2-style/fonts.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2-style/style.css
+++ b/modules/st2-style/style.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2-style/style.css
+++ b/modules/st2-style/style.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 @import "normalize.css/normalize.css";

--- a/modules/st2-style/style.js
+++ b/modules/st2-style/style.js
@@ -1,7 +1,15 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import './style.css';

--- a/modules/st2-test-utils/bootstrap/events.js
+++ b/modules/st2-test-utils/bootstrap/events.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 global.document = {
   ...global.document,

--- a/modules/st2-test-utils/bootstrap/location.js
+++ b/modules/st2-test-utils/bootstrap/location.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 global.window = {
   ...global.window,

--- a/modules/st2-test-utils/bootstrap/misc.js
+++ b/modules/st2-test-utils/bootstrap/misc.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 global.document = {
   ...global.document,

--- a/modules/st2-test-utils/bootstrap/st2constants.js
+++ b/modules/st2-test-utils/bootstrap/st2constants.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 global.window = {
   ...global.window,

--- a/modules/st2-test-utils/bootstrap/storage.js
+++ b/modules/st2-test-utils/bootstrap/storage.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 global.localStorage = {
   ...global.localStorage,

--- a/modules/st2-test-utils/bootstrap/title.js
+++ b/modules/st2-test-utils/bootstrap/title.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 global.document = {
   ...global.document,

--- a/modules/st2-test-utils/test-utils.js
+++ b/modules/st2-test-utils/test-utils.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import TestRenderer from 'react-test-renderer';
 
@@ -22,7 +30,7 @@ export class ReactInstanceTester {
   get type() {
     return this._instance.type;
   }
-  
+
   get props() {
     return this._instance.props || {};
   }

--- a/modules/st2flow-canvas/astar.js
+++ b/modules/st2flow-canvas/astar.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // This code is derived from javascript-astar 0.4.1
 // http://github.com/bgrins/javascript-astar

--- a/modules/st2flow-canvas/collapse-button.js
+++ b/modules/st2flow-canvas/collapse-button.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-canvas/const.js
+++ b/modules/st2flow-canvas/const.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import Vector from './vector';
 

--- a/modules/st2flow-canvas/index.js
+++ b/modules/st2flow-canvas/index.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-canvas/path/index.js
+++ b/modules/st2flow-canvas/path/index.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import Vector from '../vector';
 import type { Direction } from './line';

--- a/modules/st2flow-canvas/path/line.js
+++ b/modules/st2flow-canvas/path/line.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import Vector from '../vector';
 import { ORBIT_DISTANCE } from '../const';

--- a/modules/st2flow-canvas/poisson-rect.js
+++ b/modules/st2flow-canvas/poisson-rect.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 export interface Sampler {

--- a/modules/st2flow-canvas/routing-graph.js
+++ b/modules/st2flow-canvas/routing-graph.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 import { Graph } from './astar';

--- a/modules/st2flow-canvas/style.css
+++ b/modules/st2flow-canvas/style.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2flow-canvas/style.css
+++ b/modules/st2flow-canvas/style.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 :root {

--- a/modules/st2flow-canvas/task.js
+++ b/modules/st2flow-canvas/task.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-canvas/toolbar.js
+++ b/modules/st2flow-canvas/toolbar.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-canvas/transition.js
+++ b/modules/st2flow-canvas/transition.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-canvas/vector.js
+++ b/modules/st2flow-canvas/vector.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-details/index.js
+++ b/modules/st2flow-details/index.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-details/layout.js
+++ b/modules/st2flow-details/layout.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-details/meta-panel.js
+++ b/modules/st2flow-details/meta-panel.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-details/mistral-properties.js
+++ b/modules/st2flow-details/mistral-properties.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-details/mistral-transition.js
+++ b/modules/st2flow-details/mistral-transition.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-details/orquesta-properties.js
+++ b/modules/st2flow-details/orquesta-properties.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-details/orquesta-transition.js
+++ b/modules/st2flow-details/orquesta-transition.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-details/parameter-editor.js
+++ b/modules/st2flow-details/parameter-editor.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-details/parameter.js
+++ b/modules/st2flow-details/parameter.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-details/parameters-panel.js
+++ b/modules/st2flow-details/parameters-panel.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-details/property.js
+++ b/modules/st2flow-details/property.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-details/string-properties.js
+++ b/modules/st2flow-details/string-properties.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 import * as React from 'react';

--- a/modules/st2flow-details/style.css
+++ b/modules/st2flow-details/style.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2flow-details/style.css
+++ b/modules/st2flow-details/style.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 :root {

--- a/modules/st2flow-details/task-details.js
+++ b/modules/st2flow-details/task-details.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-details/task-list.js
+++ b/modules/st2flow-details/task-list.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-details/task.js
+++ b/modules/st2flow-details/task.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-editor/index.js
+++ b/modules/st2flow-editor/index.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-editor/style.css
+++ b/modules/st2flow-editor/style.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2flow-editor/style.css
+++ b/modules/st2flow-editor/style.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 .component {

--- a/modules/st2flow-header/index.js
+++ b/modules/st2flow-header/index.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-header/style.css
+++ b/modules/st2flow-header/style.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2flow-header/style.css
+++ b/modules/st2flow-header/style.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 .component {

--- a/modules/st2flow-model/base-class.js
+++ b/modules/st2flow-model/base-class.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 

--- a/modules/st2flow-model/base-model.js
+++ b/modules/st2flow-model/base-model.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 

--- a/modules/st2flow-model/event-emitter.js
+++ b/modules/st2flow-model/event-emitter.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 

--- a/modules/st2flow-model/index.js
+++ b/modules/st2flow-model/index.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import OrquestaModel from './model-orquesta';
 import MistralModel from './model-mistral';

--- a/modules/st2flow-model/interfaces.js
+++ b/modules/st2flow-model/interfaces.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 import type { JpathKey, Range } from '@stackstorm/st2flow-yaml';

--- a/modules/st2flow-model/layout.js
+++ b/modules/st2flow-model/layout.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 

--- a/modules/st2flow-model/model-meta.js
+++ b/modules/st2flow-model/model-meta.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 

--- a/modules/st2flow-model/model-mistral.js
+++ b/modules/st2flow-model/model-mistral.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 

--- a/modules/st2flow-model/model-orquesta.js
+++ b/modules/st2flow-model/model-orquesta.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 import _ from 'lodash';

--- a/modules/st2flow-model/tests/data/common-data.js
+++ b/modules/st2flow-model/tests/data/common-data.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import MistralModel from '../../model-mistral';
 import OruestaModel from '../../model-orquesta';

--- a/modules/st2flow-model/tests/test-common.js
+++ b/modules/st2flow-model/tests/test-common.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import chai, { expect } from 'chai';
 import chaiSubset from 'chai-subset';

--- a/modules/st2flow-model/tests/test-model-meta.js
+++ b/modules/st2flow-model/tests/test-model-meta.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import { expect } from 'chai';
 import fs from 'fs';

--- a/modules/st2flow-model/tests/test-model-mistral.js
+++ b/modules/st2flow-model/tests/test-model-mistral.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import { expect } from 'chai';
 import fs from 'fs';

--- a/modules/st2flow-model/tests/test-model-orquesta.js
+++ b/modules/st2flow-model/tests/test-model-orquesta.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import { expect } from 'chai';
 import fs from 'fs';

--- a/modules/st2flow-notifications/index.js
+++ b/modules/st2flow-notifications/index.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 

--- a/modules/st2flow-notifications/style.css
+++ b/modules/st2flow-notifications/style.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2flow-notifications/style.css
+++ b/modules/st2flow-notifications/style.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 .component {

--- a/modules/st2flow-palette/action.js
+++ b/modules/st2flow-palette/action.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-palette/index.js
+++ b/modules/st2flow-palette/index.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-palette/pack.js
+++ b/modules/st2flow-palette/pack.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //@flow
 

--- a/modules/st2flow-palette/style.css
+++ b/modules/st2flow-palette/style.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Extreme Networks, Inc.
+Copyright 2020 Extreme Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/st2flow-palette/style.css
+++ b/modules/st2flow-palette/style.css
@@ -1,9 +1,17 @@
 /*
-Copyright 2020 Extreme Networks, Inc.
+Copyright 2019 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 .component {

--- a/modules/st2flow-perf/index.js
+++ b/modules/st2flow-perf/index.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 const debug = require('debug')('st2flow.perf');
 const IS_NODE = typeof process === 'object' && Object.prototype.toString.call(process) === '[object process]';

--- a/modules/st2flow-yaml/crawler.js
+++ b/modules/st2flow-yaml/crawler.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 

--- a/modules/st2flow-yaml/index.js
+++ b/modules/st2flow-yaml/index.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 

--- a/modules/st2flow-yaml/objectifier.js
+++ b/modules/st2flow-yaml/objectifier.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 

--- a/modules/st2flow-yaml/stringifier.js
+++ b/modules/st2flow-yaml/stringifier.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 

--- a/modules/st2flow-yaml/tests/refinery/js-in-yaml.js
+++ b/modules/st2flow-yaml/tests/refinery/js-in-yaml.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // This is an example of YAML that contains JS-style data objects.
 // The tests will mutate this data, and the expected result is

--- a/modules/st2flow-yaml/tests/refinery/obj-to-yaml.js
+++ b/modules/st2flow-yaml/tests/refinery/obj-to-yaml.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // This is a plain JS object that will get converted to the expected
 // YAML below. It is intentionally complex to ensure we can "refine"

--- a/modules/st2flow-yaml/tests/test-crawler.js
+++ b/modules/st2flow-yaml/tests/test-crawler.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import fs from 'fs';
 import path from 'path';

--- a/modules/st2flow-yaml/tests/test-refinery.js
+++ b/modules/st2flow-yaml/tests/test-refinery.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import { expect } from 'chai';
 import factory from '../token-factory';

--- a/modules/st2flow-yaml/tests/test-token-set.js
+++ b/modules/st2flow-yaml/tests/test-token-set.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import fs from 'fs';
 import path from 'path';

--- a/modules/st2flow-yaml/token-factory.js
+++ b/modules/st2flow-yaml/token-factory.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 

--- a/modules/st2flow-yaml/token-refinery.js
+++ b/modules/st2flow-yaml/token-refinery.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 

--- a/modules/st2flow-yaml/token-set.js
+++ b/modules/st2flow-yaml/token-set.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 

--- a/modules/st2flow-yaml/types.js
+++ b/modules/st2flow-yaml/types.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 

--- a/modules/st2flow-yaml/util.js
+++ b/modules/st2flow-yaml/util.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // @flow
 

--- a/rpm/LICENSE
+++ b/rpm/LICENSE
@@ -1,123 +1,202 @@
-Extreme Workflow Composer EULA
------------------------------------------
 
-This document is an agreement (“Agreement”) between You, the end user, and Extreme Networks, Inc., on behalf of itself and its Affiliates (“Extreme”) that sets forth your rights and obligations with respect to the “Licensed Materials”. BY INSTALLING SOFTWARE AND/OR THE LICENSE KEY FOR THE SOFTWARE (“License Key”) (collectively, “Licensed Software”), IF APPLICABLE, COPYING, OR OTHERWISE USING THE LICENSED SOFTWARE AND/OR ANY OF THE LICENSED MATERIALS UNDER THIS AGREEMENT, YOU ARE AGREEING TO BE BOUND BY THE TERMS OF THIS AGREEMENT, WHICH INCLUDES THE LICENSE(S) AND THE LIMITATION(S) OF WARRANTY AND DISCLAIMER(S)/LIMITATION(S) OF LIABILITY. IF YOU DO NOT AGREE TO THE TERMS OF THIS AGREEMENT, RETURN THE LICENSE KEY (IF APPLICABLE) TO EXTREME OR YOUR DEALER, IF ANY, OR DO NOT USE THE LICENSED SOFTWARE AND/OR LICENSED MATERIALS AND CONTACT EXTREME OR YOUR DEALER WITHIN TEN (10) DAYS FOLLOWING THE DATE OF RECEIPT TO ARRANGE FOR A REFUND. IF YOU HAVE ANY QUESTIONS ABOUT THIS AGREEMENT, CONTACT EXTREME, Attn: LegalTeam@extremenetworks.com.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-1. DEFINITIONS. “Affiliates” means any person, partnership, corporation, limited liability company, or other form of enterprise that directly or indirectly through one or more intermediaries, controls, or is controlled by, or is under common control with the party specified. “Server Application” means the software application associated to software authorized for installation (per License Key, if applicable) on one or more of Your servers as further defined in the Ordering Documentation. “Client Application” shall refer to the application to access the Server Application. “Network Device” for purposes of this Agreement shall mean a physical computer device, appliance, appliance component, controller, wireless access point, or virtual appliance as further described within the applicable product documentation, which includes the Order Documentation. “Licensed Materials” means the Licensed Software (including the Server Application and Client Application), Network Device (if applicable), Firmware, media embodying software, and the accompanying documentation. “Concurrent User” shall refer to any of Your individual employees who You provide access to the Server Application at any one time. “Firmware” refers to any software program or code embedded in chips or other media. “Standalone” software is software licensed for use independent of any hardware purchase as identified in the Ordering Documentation. “Licensed Software” collectively refers to the software, including Standalone software, Firmware, Server Application, Client Application or other application licensed with conditional use parameters as defined in the Ordering Documentation. “Ordering Documentation” shall mean the applicable price quotation, corresponding purchase order, relevant invoice, order acknowledgement, and accompanying documentation or specifications for the products and services purchased, acquired or licensed hereunder from Extreme either directly or indirectly.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-2. TERM. This Agreement is effective from the date on which You accept the terms and conditions of this Agreement via click-through, commence using the products and services or upon delivery of the License Key if applicable, and shall be effective until terminated. In the case of Licensed Materials offered on a subscription basis, the term of “licensed use” shall be as defined within Your Ordering Documentation.
+   1. Definitions.
 
-3. GRANT OF LICENSE. Extreme will grant You a non-transferable, non-sublicensable, non-exclusive license to use the Licensed Materials and the accompanying documentation for Your own business purposes subject to the terms and conditions of this Agreement, applicable licensing restrictions, and any term, user server networking device, field of use, or other restrictions as set forth in Your Ordering Documentation. If the Licensed Materials are being licensed on a subscription and/or capacity basis, the applicable term and/or capacity limit of the license shall be specified in Your Ordering Documentation. You may install and use the Licensed Materials as permitted by the license type purchased as described below in License Types. The license type purchased is specified on the invoice issued to You by Extreme or Your dealer, if any. YOU MAY NOT USE, COPY, OR MODIFY THE LICENSED MATERIALS, IN WHOLEOR IN PART, EXCEPT AS EXPRESSLY PROVIDED IN THIS AGREEMENT.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-4. LICENSE TYPES.
-* Single User, Single Network Device. Under the terms of this license type, the license granted to You by Extreme authorizes You to use the Licensed Materials as bundled with a single Network Device as identified by a unique serial number for the applicable Term, if and as specified in Your Ordering Documentation, or any replacement for that network device for that same Term, for internal use only. A separate license, under a separate License Agreement, is required for any other network device on which You or another individual, employee or other third party intend to use the Licensed Materials. A separate license under a separate License Agreement is also required if You wish to use a Client license (as described below).
-* Single User, Multiple Network Device. Under the terms of this license type, the license granted to You by Extreme authorizes You to use the Licensed Materials with a defined amount of Network Devices as defined in the Ordering Documentation.
-* Client. Under the terms of the Client license, the license granted to You by Extreme will authorize You to install the License Key for the Licensed Materials on your server and allow the specific number of Concurrent Users as ordered by you and is set forth in Your Ordering Documentation. A separate license is required for each additional Concurrent User.
-* Standalone. Software or other Licensed Materials licensed to You for use independent of any Network Device.
-* Subscription. Licensed Materials, and inclusive Software, Network Device or related appliance updates and maintenance services, licensed to You for use during a subscription period as defined in Your applicable Ordering Documentation.
-* Capacity. Under the terms of this license, the license granted to You by Extreme authorizes You to use the Licensed Materials up to the amount of capacity or usage as defined in the Ordering Documentation.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-5. AUDIT RIGHTS. You agree that Extreme may audit Your use of the Licensed Materials for compliance with these terms and Your License Type at any time, upon reasonable notice. In the event that such audit reveals any use of the Licensed Materials by You other than in full compliance with the license granted and the terms of this Agreement, Extreme reserves the right to charge You for all reasonable expenses related to such audit in addition to any other liabilities and overages applicable as a result of such non-compliance, including but not limited to additional fees for Concurrent Users, excess capacity or usage over and above those specifically granted to You. From time to time, the Licensed Materials may upload information about the Licensed Materials and the associated usage to Extreme. This is to verify the Licensed Materials are being used in accordance with a valid license and/or entitlement. By using the Licensed Materials, you
-consent to the transmission of this information.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-6. RESTRICTION AGAINST COPYING OR MODIFYING LICENSED MATERIALS. Except as expressly permitted in this Agreement, You may not copy or otherwise reproduce the Licensed Materials. In no event does the limited copying or reproduction permitted under this Agreement include the right to decompile,
-disassemble, electronically transfer, or reverse engineer the Licensed Materials, including the Licensed Software, or to translate the
-Licensed Materials into another computer language. The media embodying the Licensed Materials may be copied by You, in whole or
-in part, into printed or machine readable form, in sufficient numbers only for backup or archival purposes, or to replace a worn or defective
-copy. However, You agree not to have more than two (2) copies of the Licensed Software in whole or in part, including the original media, in
-your possession for said purposes without Extreme’ prior written consent, and in no event shall You operate more copies of the Licensed
-Software than the specific licenses granted to You. You may not copy or reproduce the documentation. You agree to maintain appropriate
-records of the location of the original media and all copies of the Licensed Software, in whole or in part, made by You. Any portion of
-the Licensed Software included in any such modular work shall be used only on a single computer for internal purposes and shall remain
-subject to all the terms and conditions of this Agreement. You agree to include any copyright or other proprietary notice set forth on the
-label of the media embodying the Licensed Software on any copy of the Licensed Software in any form, in whole or in part, or on any
-modification of the Licensed Software or any such modular work containing the Licensed Software or any part thereof.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-7. TITLE AND PROPRIETARY RIGHTS
-(a) The Licensed Materials are copyrighted works and are the sole and exclusive property of Extreme, any company or a division thereof
-which Extreme controls or is controlled by, or which may result from the merger or consolidation with Extreme (its “Affiliates”), and/or
-their suppliers. This Agreement conveys a limited right to operate the Licensed Materials and shall not be construed to convey title to the
-Licensed Materials to You. There are no implied rights. You shall not sell, lease, transfer, sublicense, dispose of, or otherwise make available
-the Licensed Materials or any portion thereof, to any other party.
-(b) You further acknowledge that in the event of a breach of this Agreement, Extreme shall suffer severe and irreparable damages for
-which monetary compensation alone will be inadequate. You therefore agree that in the event of a breach of this Agreement, Extreme
-shall be entitled to monetary damages and its reasonable attorney’s fees and costs in enforcing this Agreement, as well as injunctive relief
-to restrain such breach, in addition to any other remedies available to Extreme.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-8. PROTECTION AND SECURITY. In the performance of this
-Agreement or in contemplation thereof, You and your employees and agents may have access to private or confidential information owned
-or controlled by Extreme relating to the Licensed Materials supplied hereunder including, but not limited to, product specifications and
-schematics, and such information may contain proprietary details and disclosures. All information and data so acquired by You or your
-employees or agents under this Agreement or in contemplation hereof shall be and shall remain Extreme’ exclusive property, and You shall
-use all commercially reasonable efforts to keep, and have your employees and agents keep, any and all such information and data
-confidential, and shall not copy, publish, or disclose it to others, without Extreme’ prior written approval, and shall return such
-information and data to Extreme at its request. Nothing herein shall limit your use or dissemination of information not actually derived Extreme or of information which has been or subsequently is made public by Extreme, or a third party having authority to do so. You agree not to deliver or otherwise make available the Licensed Materials or any part thereof, including without limitation the object or source code (if provided) of the Licensed Software, to any party other than Extreme or its employees, except for purposes specifically related to your use of the Licensed Materials on a single computer as expressly provided in this Agreement, without the prior written consent of Extreme. You acknowledge that the Licensed Materials
-contain valuable confidential information and trade secrets, and that unauthorized use, copying and/or disclosure thereof are harmful to
-Extreme or its Affiliates and/or its/their software suppliers.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-9. MAINTENANCE AND UPDATES. Except as otherwise defined below, updates and certain maintenance and support services, if any, shall be provided to You pursuant to the terms of an Extreme Service and Maintenance Agreement, if Extreme and You enter into such an agreement. Except as specifically set forth in such agreement, Extreme shall not be under any obligation to provide updates, modifications, or enhancements, or maintenance and support services for the Licensed Materials to You. If you have purchased Licensed Materials on a subscription basis then the applicable service terms for
-Your Licensed Materials are as provided in Your Ordering Documentation. Extreme will perform the maintenance and updates in a timely and professional manner, during the Term of Your subscription, using qualified and experienced personnel. You will cooperate in good faith with Extreme in the performance of the support services including, but not limited to, providing Extreme with:
-(a) access to the Extreme Licensed Materials (and related systems); and
-(b) reasonably requested assistance and information. Further information about the applicable maintenance and updates terms can
-be found on Extreme’s website at http://www.extremenetworks.com/support/end-of-sale-and-end-ofsupport-products.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-10. DEFAULT AND TERMINATION. In the event that You shall fail to keep, observe, or perform any obligation under this Agreement,
-including a failure to pay any sums due to Extreme, or in the event that you become insolvent or seek protection, voluntarily or involuntarily,
-under any bankruptcy law, Extreme may, in addition to any other remedies it may have under law, terminate the License and any other
-agreements between Extreme and You.
-(a) Immediately after any termination of the Agreement, Your licensed subscription term, or if You have for any reason discontinued
-use of Licensed Materials, You shall return to Extreme the original and any copies of the Licensed Materials and remove the Licensed
-Materials, including an Licensed Software, from any modular works made pursuant to Section 3, and certify in writing that through your
-best efforts and to the best of your knowledge the original and all copies of the terminated or discontinued Licensed Materials have been
-returned to Extreme.
-(b) Sections 1, 7, 8, 10, 11, 12, 13, 14 and 15 shall survive termination of this Agreement for any reason.
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-11. EXPORT REQUIREMENTS. You are advised that the Licensed Materials, including the Licensed Software is of United States origin
-and subject to United States Export Administration Regulations; diversion contrary to United States law and regulation is prohibited.
-You agree not to directly or indirectly export, import or transmit the Licensed Materials, including the Licensed Software to any country,
-end user or for any Use that is prohibited by applicable United States regulation or statute (including but not limited to those countries
-embargoed from time to time by the United States government); or contrary to the laws or regulations of any other governmental entity
-that has jurisdiction over such export, import, transmission or Use.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-12. UNITED STATES GOVERNMENT RESTRICTED RIGHTS. The Licensed Materials (i) were developed solely at private expense;
-(ii) contain “restricted computer software” submitted with restricted rights in accordance with section 52.227-19 (a) through (d) of the
-Commercial Computer Software-Restricted Rights Clause and its successors, and (iii) in all respects is proprietary data belonging to
-Extreme and/or its suppliers. For Department of Defense units, the Licensed Materials are considered commercial computer software in
-accordance with DFARS section 227.7202-3 and its successors, and use, duplication, or disclosure by the U.S. Government is subject to
-restrictions set forth herein.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-13. LIMITED WARRANTY AND LIMITATION OF LIABILITY. Extreme warrants to You that (a) the initially-shipped version of the
-Licensed Materials will materially conform to the Documentation; and (b) the media on which the Licensed Software is recorded will be free
-from material defects for a period of ninety (90) days from the date of delivery to You or such other minimum period required under
-applicable law. Extreme does not warrant that Your use of the Licensed Materials will be error-free or uninterrupted.
-NEITHER EXTREME NOR ITS AFFILIATES MAKE ANY OTHER WARRANTY OR REPRESENTATION, EXPRESS OR IMPLIED, WITH RESPECT TO THE LICENSED MATERIALS, WHICH ARE
-LICENSED "AS IS". THE LIMITED WARRANTY AND REMEDY PROVIDED ABOVE ARE EXCLUSIVE AND IN LIEU OF ALL OTHER WARRANTIES, INCLUDING IMPLIED WARRANTIES
-OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, WHICH ARE EXPRESSLY DISCLAIMED, AND STATEMENTS OR REPRESENTATIONS MADE BY ANY
-OTHER PERSON OR FIRM ARE VOID. IN NO EVENT WILL EXTREME OR ANY OTHER PARTY WHO HAS BEEN INVOLVED IN THE CREATION, PRODUCTION OR DELIVERY
-OF THE LICENSED MATERIALS BE LIABLE FOR SPECIAL, DIRECT, INDIRECT, RELIANCE, INCIDENTAL OR CONSEQUENTIAL DAMAGES, INCLUDING LOSS OF DATA OR PROFITS OR FOR INABILITY TO USE THE LICENSED MATERIALS, TO ANY PARTY EVEN IF EXTREME OR SUCH OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. IN NO EVENT SHALL EXTREME OR SUCH OTHER PARTY'S LIABILITY FOR ANY DAMAGES OR LOSS TO YOU OR ANY OTHER PARTY EXCEED THE LICENSE FEE YOU PAID FOR THE LICENSED MATERIALS.
-Some states do not allow limitations on how long an implied warranty lasts and some states do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation and exclusion may not apply to You. This limited warranty gives You specific legal rights, and You may also have other rights which vary from state to state.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-14. JURISDICTION. The rights and obligations of the parties to this Agreement shall be governed and construed in accordance with the laws and in the State and Federal courts of the State of California, without regard to its rules with respect to choice of law. You waive any objections to the personal jurisdiction and venue of such courts. None of the 1980 United Nations Convention on the Limitation Period in the International Sale of Goods, and the Uniform Computer Information Transactions Act shall apply to this Agreement.
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-15. FREE AND OPEN SOURCE SOFTWARE. Portions of the Software (Open Source Software) provided to you may be subject to alicense that permits you to modify these portions and redistribute the modifications (an Open Source License). Your use, modification and redistribution of the Open Source Software are governed by the terms and conditions of the applicable Open Source License. More details regarding the Open Source Software and the applicable Open Source Licenses are available at www.extremenetworks.com/services/SoftwareLicensing.aspx. Some of the Open Source software may be subject to the GNU General Public License v.x (GPL) or the Lesser General Public Library (LGPL), copies of which are provided with the
-Licensed Materials and are further available for review at www.extremenetworks.com/services/SoftwareLicensing.aspx, or upon request as directed herein. In accordance with the terms of the GPL and LGPL, you may request a copy of the relevant source code. See the Software Licensing web site for additional details. This offer is valid for up to three years from the date of original download of the software.
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-16. GENERAL.
-(a) This Agreement is the entire agreement between Extreme and You regarding the Licensed Materials, and all prior agreements, representations, statements, and undertakings, oral or written, are hereby expressly superseded and canceled.
-(b) This Agreement may not be changed or amended except in writing signed by both parties hereto.
-(c) You represent that You have full right and/or authorization to enter into this Agreement.
-(d) This Agreement shall not be assignable by You without the express written consent of Extreme. The rights of Extreme and Your
-obligations under this Agreement shall inure to the benefit of Extreme’ assignees, licensors, and licensees.
-(e) Section headings are for convenience only and shall not be considered in the interpretation of this Agreement.
-(f) The provisions of the Agreement are severable and if any one or more of the provisions hereof are judicially determined to be illegal or
-otherwise unenforceable, in whole or in part, the remaining provisions of this Agreement shall nevertheless be binding on and enforceable by
-and between the parties hereto.
-(g) Extreme’s waiver of any right shall not constitute waiver of that right in future. This Agreement constitutes the entire understanding
-between the parties with respect to the subject matter hereof, and all prior agreements, representations, statements and undertakings, oral or
-written, are hereby expressly superseded and canceled. No purchase order shall supersede this Agreement.
-(h) Should You have any questions regarding this Agreement, You may contact Extreme at the address set forth below. Any notice or
-other communication to be sent to Extreme must be mailed by certified mail to the following address:
-Extreme Networks, Inc.
-145 Rio Robles
-San Jose, CA 95134 United States
-ATTN: Legal Department
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/rpm/st2flow.spec
+++ b/rpm/st2flow.spec
@@ -14,8 +14,8 @@ Summary:        Extreme Workflow Designer
 
 Requires: perl, st2web
 
-License:        Extreme Workflow Composer EULA
-URL:            https://www.extremenetworks.com/product/workflow-composer/
+License:        Apache License, Version 2.0
+URL:            https://github.com/StackStorm/st2flow
 Source0:        st2flow
 
 Prefix:         /opt/stackstorm/static/webui/flow

--- a/store.js
+++ b/store.js
@@ -1,8 +1,16 @@
 // Copyright 2020 Extreme Networks, Inc.
 //
-// Unauthorized copying of this file, via any medium is strictly
-// prohibited. Proprietary and confidential. See the LICENSE file
-// included with this work for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import { createScopedStore } from '@stackstorm/module-store';
 

--- a/style.css
+++ b/style.css
@@ -1,9 +1,17 @@
 /*
 Copyright 2020 Extreme Networks, Inc.
 
-Unauthorized copying of this file, via any medium is strictly
-prohibited. Proprietary and confidential. See the LICENSE file
-included with this work for details.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 @import 'node_modules/@stackstorm/st2-style/style.css';


### PR DESCRIPTION
closes #374 

Updates `LICENSE` to Apache 2.0

Also, for the following files:
- `*.js`
- `*.css`
- `README.md`

Changes License from
```
Copyright 2020 Extreme Networks, Inc.

Unauthorized copying of this file, via any medium is strictly
prohibited. Proprietary and confidential. See the LICENSE file
included with this work for details.
```

to
```
Copyright 2020 Extreme Networks, Inc.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
```